### PR TITLE
turbojpeg warning [-Wattributes]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,7 +265,7 @@ AC_SUBST(VERSION_SCRIPT_FLAG)
 AC_MSG_CHECKING(for inline)
 ljt_cv_inline=""
 AC_TRY_COMPILE(, [} __attribute__((always_inline)) int foo() { return 0; }
-int bar() { return foo();], ljt_cv_inline="__attribute__((always_inline))",
+int bar() { return foo();], ljt_cv_inline="inline __attribute__((always_inline))",
 AC_TRY_COMPILE(, [} __inline__ int foo() { return 0; }
 int bar() { return foo();], ljt_cv_inline="__inline__",
 AC_TRY_COMPILE(, [} __inline int foo() { return 0; }


### PR DESCRIPTION
warning: always_inline function might not be inlinable
Patch from http://sourceforge.net/p/libjpeg-turbo/patches/56/
