### PR TITLE
Parse quality as float

### DIFF
--- a/jcparam.c
+++ b/jcparam.c
@@ -151,14 +151,20 @@ jpeg_set_linear_quality (j_compress_ptr cinfo, int scale_factor,
 
 GLOBAL(int)
 jpeg_quality_scaling (int quality)
+{
+  return jpeg_float_quality_scaling(quality);
+}
+
+GLOBAL(float)
+jpeg_float_quality_scaling(float quality)
 /* Convert a user-specified quality rating to a percentage scaling factor
  * for an underlying quantization table, using our recommended scaling curve.
  * The input 'quality' factor should be 0 (terrible) to 100 (very good).
  */
 {
   /* Safety limit on quality factor.  Convert 0 to 1 to avoid zero divide. */
-  if (quality <= 0) quality = 1;
-  if (quality > 100) quality = 100;
+  if (quality <= 0.f) quality = 1.f;
+  if (quality > 100.f) quality = 100.f;
 
   /* The basic table is used as-is (scaling 100) for a quality of 50.
    * Qualities 50..100 are converted to scaling percentage 200 - 2*Q;
@@ -166,10 +172,10 @@ jpeg_quality_scaling (int quality)
    * to make all the table entries 1 (hence, minimum quantization loss).
    * Qualities 1..50 are converted to scaling percentage 5000/Q.
    */
-  if (quality < 50)
-    quality = 5000 / quality;
+  if (quality < 50.f)
+    quality = 5000.f / quality;
   else
-    quality = 200 - quality*2;
+    quality = 200.f - quality*2.f;
 
   return quality;
 }

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -1060,6 +1060,7 @@ EXTERN(void) jpeg_add_quant_table JPP((j_compress_ptr cinfo, int which_tbl,
 				       int scale_factor,
 				       boolean force_baseline));
 EXTERN(int) jpeg_quality_scaling JPP((int quality));
+EXTERN(float) jpeg_float_quality_scaling JPP((float quality));
 EXTERN(void) jpeg_simple_progression JPP((j_compress_ptr cinfo));
 EXTERN(void) jpeg_suppress_tables JPP((j_compress_ptr cinfo,
 				       boolean suppress));

--- a/rdswitch.c
+++ b/rdswitch.c
@@ -336,31 +336,31 @@ set_quality_ratings (j_compress_ptr cinfo, char *arg, boolean force_baseline)
  * If there are more q-table slots than parameters, the last value is replicated.
  */
 {
-  int val = 75;			/* default value */
+  float val = 75.f;             /* default value */
   int tblno;
   char ch;
 
   for (tblno = 0; tblno < NUM_QUANT_TBLS; tblno++) {
     if (*arg) {
-      ch = ',';			/* if not set by sscanf, will be ',' */
-      if (sscanf(arg, "%d%c", &val, &ch) < 1)
-	return FALSE;
-      if (ch != ',')		/* syntax check */
-	return FALSE;
+      ch = ',';                 /* if not set by sscanf, will be ',' */
+      if (sscanf(arg, "%f%c", &val, &ch) < 1)
+        return FALSE;
+      if (ch != ',')            /* syntax check */
+        return FALSE;
       /* Convert user 0-100 rating to percentage scaling */
 #if JPEG_LIB_VERSION >= 70
-      cinfo->q_scale_factor[tblno] = jpeg_quality_scaling(val);
+      cinfo->q_scale_factor[tblno] = jpeg_float_quality_scaling(val);
 #else
-      q_scale_factor[tblno] = jpeg_quality_scaling(val);
+      q_scale_factor[tblno] = jpeg_float_quality_scaling(val);
 #endif
       while (*arg && *arg++ != ',') /* advance to next segment of arg string */
 	;
     } else {
       /* reached end of parameter, set remaining factors to last value */
 #if JPEG_LIB_VERSION >= 70
-      cinfo->q_scale_factor[tblno] = jpeg_quality_scaling(val);
+      cinfo->q_scale_factor[tblno] = jpeg_float_quality_scaling(val);
 #else
-      q_scale_factor[tblno] = jpeg_quality_scaling(val);
+      q_scale_factor[tblno] = jpeg_float_quality_scaling(val);
 #endif
     }
   }


### PR DESCRIPTION
Allows `cjpeg -quality 74.5`, etc. It helps creating files with an exact file size for fair comparisons.

Only affects quality scaling. `q_scale_factor` is still an int for ABI compatibility, but even that is good enough.
