### PR TITLE
Add .gitignore for autotools files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+Makefile.in
+/autom4te.cache
+/aclocal.m4
+/compile
+/configure
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+/config.guess
+/config.h.in
+/config.sub
+/ltmain.sh


### PR DESCRIPTION
This makes development work less error prone when committing.

Partially based off of: https://github.com/github/gitignore/blob/master/Autotools.gitignore
