### PR TITLE
Float version of overshoot deringing

### DIFF
--- a/cjpeg.c
+++ b/cjpeg.c
@@ -188,6 +188,7 @@ usage (void)
   fprintf(stderr, "  -tune-ssim     Tune trellis optimization for SSIM\n");
   fprintf(stderr, "  -tune-ms-ssim  Tune trellis optimization for MS-SSIM\n");
   fprintf(stderr, "Switches for advanced users:\n");
+  fprintf(stderr, "  -noovershoot   Disable black-on-white deringing via overshoot\n");
 #ifdef C_ARITH_CODING_SUPPORTED
   fprintf(stderr, "  -arithmetic    Use arithmetic coding\n");
 #endif
@@ -534,7 +535,9 @@ parse_switches (j_compress_ptr cinfo, int argc, char **argv,
       cinfo->lambda_log_scale2 = 15.5;
       cinfo->use_lambda_weight_tbl = TRUE;
       jpeg_set_quality(cinfo, 75, TRUE);
-      
+
+    } else if (keymatch(arg, "noovershoot", 11)) {
+      cinfo->overshoot_deringing = FALSE;
     } else {
       fprintf(stderr, "%s: unknown option '%s'\n", progname, arg);
       usage();                  /* bogus switch */

--- a/jcdctmgr.c
+++ b/jcdctmgr.c
@@ -672,7 +672,9 @@ forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
     /* Load data into workspace, applying unsigned->signed conversion */
     (*do_convsamp) (sample_data, start_col, workspace);
 
-    (*do_preprocess) (workspace, qtbl);
+    if (do_preprocess) {
+      (*do_preprocess) (workspace, qtbl);
+    }
 
     /* Perform the DCT */
     (*do_dct) (workspace);
@@ -799,7 +801,9 @@ forward_DCT_float (j_compress_ptr cinfo, jpeg_component_info * compptr,
     /* Load data into workspace, applying unsigned->signed conversion */
     (*do_convsamp) (sample_data, start_col, workspace);
 
-    (*do_preprocess) (workspace, qtbl);
+    if (do_preprocess) {
+      (*do_preprocess) (workspace, qtbl);
+    }
 
     /* Perform the DCT */
     (*do_dct) (workspace);
@@ -1273,7 +1277,11 @@ jinit_forward_dct (j_compress_ptr cinfo)
     else
       fdct->convsamp = convsamp;
 
-    fdct->preprocess = preprocess_deringing;
+    if (cinfo->overshoot_deringing) {
+      fdct->preprocess = preprocess_deringing;
+    } else {
+      fdct->preprocess = NULL;
+    }
 
     if (jsimd_can_quantize())
       fdct->quantize = jsimd_quantize;
@@ -1288,7 +1296,11 @@ jinit_forward_dct (j_compress_ptr cinfo)
     else
       fdct->float_convsamp = convsamp_float;
 
-    fdct->float_preprocess = float_preprocess_deringing;
+    if (cinfo->overshoot_deringing) {
+      fdct->float_preprocess = float_preprocess_deringing;
+    } else {
+      fdct->float_preprocess = NULL;
+    }
 
     if (jsimd_can_quantize_float())
       fdct->float_quantize = jsimd_quantize_float;

--- a/jcparam.c
+++ b/jcparam.c
@@ -293,6 +293,8 @@ jpeg_set_defaults (j_compress_ptr cinfo)
   cinfo->do_fancy_downsampling = TRUE;
 #endif
 
+  cinfo->overshoot_deringing = cinfo->use_moz_defaults;
+
   /* No input smoothing */
   cinfo->smoothing_factor = 0;
 

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -386,13 +386,14 @@ struct jpeg_compress_struct {
   boolean use_scans_in_trellis; /* TRUE=use scans in trellis optimization */
   boolean trellis_passes; /* TRUE=currently doing trellis-related passes */
   boolean trellis_q_opt; /* TRUE=optimize quant table in trellis loop */
-  
+  boolean overshoot_deringing; /* TRUE=preprocess input to reduce ringing of edges on white background */
+
   double norm_src[NUM_QUANT_TBLS][DCTSIZE2];
   double norm_coef[NUM_QUANT_TBLS][DCTSIZE2];
 
   int trellis_freq_split; /* splitting point for frequency in trellis quantization */
   int trellis_num_loops; /* number of trellis loops */
-  
+
   int num_scans_luma; /* # of entries in scan_info array pertaining to luma (used when optimize_scans is TRUE */
   int num_scans_luma_dc;
   int num_scans_chroma_dc;


### PR DESCRIPTION
As requested in #101 the overshoot clipping works for both int and float DCT.

Added option `-noovershoot` to disable.
