### PR TITLE
Don't warn about 16-bit quantization table entries

### DIFF
--- a/jcmarker.c
+++ b/jcmarker.c
@@ -702,10 +702,8 @@ write_frame_header (j_compress_ptr cinfo)
       if (compptr->dc_tbl_no > 1 || compptr->ac_tbl_no > 1)
         is_baseline = FALSE;
     }
-    if (prec && is_baseline) {
+    if (prec) {
       is_baseline = FALSE;
-      /* If it's baseline except for quantizer size, warn the user */
-      TRACEMS(cinfo, 0, JTRC_16BIT_TABLES);
     }
   }
 

--- a/jerror.h
+++ b/jerror.h
@@ -136,8 +136,6 @@ JMESSAGE(JERR_XMS_READ, "Read from XMS failed")
 JMESSAGE(JERR_XMS_WRITE, "Write to XMS failed")
 JMESSAGE(JMSG_COPYRIGHT, JCOPYRIGHT_SHORT)
 JMESSAGE(JMSG_VERSION, JVERSION)
-JMESSAGE(JTRC_16BIT_TABLES,
-         "Caution: quantization tables are too coarse for baseline JPEG")
 JMESSAGE(JTRC_ADOBE,
          "Adobe APP14 marker: version %d, flags 0x%04x 0x%04x, transform %d")
 JMESSAGE(JTRC_APP0, "Unknown APP0 marker (not JFIF), length %u")


### PR DESCRIPTION
The new default quantization tables trigger this warning even at reasonable quality settings. 

Since this warning has no practical significance, I've just removed it.