### PR TITLE
Larger number of DC trellis candidates

### DIFF
--- a/jcdctmgr.c
+++ b/jcdctmgr.c
@@ -875,7 +875,12 @@ static const float jpeg_lambda_weights_csf_luma[64] = {
   0.43454f, 0.42146f, 0.34609f, 0.24072f, 0.15975f, 0.10701f, 0.07558f, 0.05875f,
 };
 
-#define DC_TRELLIS_CANDIDATES 3
+#define DC_TRELLIS_MAX_CANDIDATES 9
+
+LOCAL(int) get_num_dc_trellis_candidates(int dc_quantval) {
+  // Higher qualities can tolerate higher DC distortion
+  return MIN(DC_TRELLIS_MAX_CANDIDATES, (2 + 60 / dc_quantval)|1);
+}
 
 GLOBAL(void)
 quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actbl, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks,
@@ -908,9 +913,9 @@ quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actb
   int zero_run;
   int run_bits;
   int rate;
-  float *accumulated_dc_cost[DC_TRELLIS_CANDIDATES];
-  int *dc_cost_backtrack[DC_TRELLIS_CANDIDATES];
-  JCOEF *dc_candidate[DC_TRELLIS_CANDIDATES];
+  float *accumulated_dc_cost[DC_TRELLIS_MAX_CANDIDATES];
+  int *dc_cost_backtrack[DC_TRELLIS_MAX_CANDIDATES];
+  JCOEF *dc_candidate[DC_TRELLIS_MAX_CANDIDATES];
   int mode = 1;
   float lambda_table[DCTSIZE2];
 
@@ -936,8 +941,11 @@ quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actb
     accumulated_block_cost[0] = 0;
     requires_eob[0] = 0;
   }
+
+  const int dc_trellis_candidates = get_num_dc_trellis_candidates(qtbl->quantval[0]);
+
   if (cinfo->master->trellis_quant_dc) {
-    for (i = 0; i < DC_TRELLIS_CANDIDATES; i++) {
+    for (i = 0; i < dc_trellis_candidates; i++) {
       accumulated_dc_cost[i] = (float *)malloc(num_blocks * sizeof(float));
       dc_cost_backtrack[i] = (int *)malloc(num_blocks * sizeof(int));
       dc_candidate[i] = (JCOEF *)malloc(num_blocks * sizeof(JCOEF));
@@ -991,12 +999,12 @@ quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actb
       float dc_candidate_dist;
 
       qval = (x + q/2) / q; /* quantized value (round nearest) */
-      for (k = 0; k < DC_TRELLIS_CANDIDATES; k++) {
+      for (k = 0; k < dc_trellis_candidates; k++) {
         int delta;
         int dc_delta;
         int bits;
 
-        dc_candidate[k][bi] = qval - DC_TRELLIS_CANDIDATES/2 + k;
+        dc_candidate[k][bi] = qval - dc_trellis_candidates/2 + k;
         delta = dc_candidate[k][bi] * q - x;
         dc_candidate_dist = delta * delta * lambda_dc;
         dc_candidate[k][bi] *= 1 + 2*sign;
@@ -1033,7 +1041,7 @@ quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actb
           accumulated_dc_cost[k][0] = cost;
           dc_cost_backtrack[k][0] = -1;
         } else {
-          for (l = 0; l < DC_TRELLIS_CANDIDATES; l++) {
+          for (l = 0; l < dc_trellis_candidates; l++) {
             dc_delta = dc_candidate[k][bi] - dc_candidate[l][bi-1];
 
             /* Derive number of suffix bits */
@@ -1240,7 +1248,7 @@ quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actb
   
   if (cinfo->master->trellis_quant_dc) {
     j = 0;
-    for (i = 1; i < DC_TRELLIS_CANDIDATES; i++) {
+    for (i = 1; i < dc_trellis_candidates; i++) {
       if (accumulated_dc_cost[i][num_blocks-1] < accumulated_dc_cost[j][num_blocks-1])
         j = i;
     }
@@ -1252,7 +1260,7 @@ quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actb
     /* Save DC predictor */
     *last_dc_val = coef_blocks[num_blocks-1][0];
 
-    for (i = 0; i < DC_TRELLIS_CANDIDATES; i++) {
+    for (i = 0; i < dc_trellis_candidates; i++) {
       free(accumulated_dc_cost[i]);
       free(dc_cost_backtrack[i]);
       free(dc_candidate[i]);
@@ -1285,11 +1293,11 @@ quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_bloc
   float cost;
   float run_bits;
   int rate;
-  float *accumulated_dc_cost[DC_TRELLIS_CANDIDATES];
-  int *dc_cost_backtrack[DC_TRELLIS_CANDIDATES];
-  JCOEF *dc_candidate[DC_TRELLIS_CANDIDATES];
-  int *dc_context[DC_TRELLIS_CANDIDATES];
-  
+  float *accumulated_dc_cost[DC_TRELLIS_MAX_CANDIDATES];
+  int *dc_cost_backtrack[DC_TRELLIS_MAX_CANDIDATES];
+  JCOEF *dc_candidate[DC_TRELLIS_MAX_CANDIDATES];
+  int *dc_context[DC_TRELLIS_MAX_CANDIDATES];
+
   int mode = 1;
   float lambda_table[DCTSIZE2];
   
@@ -1299,9 +1307,11 @@ quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_bloc
     Ss = 1;
   if (Se < Ss)
     return;
-  
+
+  const int dc_trellis_candidates = get_num_dc_trellis_candidates(qtbl->quantval[0]);
+
   if (cinfo->master->trellis_quant_dc) {
-    for (i = 0; i < DC_TRELLIS_CANDIDATES; i++) {
+    for (i = 0; i < dc_trellis_candidates; i++) {
       accumulated_dc_cost[i] = (float *)malloc(num_blocks * sizeof(float));
       dc_cost_backtrack[i] = (int *)malloc(num_blocks * sizeof(int));
       dc_candidate[i] = (JCOEF *)malloc(num_blocks * sizeof(JCOEF));
@@ -1347,7 +1357,7 @@ quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_bloc
     
     accumulated_zero_dist[Ss-1] = 0.0;
     accumulated_cost[Ss-1] = 0.0;
-    
+
     /* Do DC coefficient */
     if (cinfo->master->trellis_quant_dc) {
       int sign = src[bi][0] >> 31;
@@ -1359,14 +1369,14 @@ quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_bloc
       qval = (x + q/2) / q; /* quantized value (round nearest) */
       
       /* loop over candidates in current block */
-      for (k = 0; k < DC_TRELLIS_CANDIDATES; k++) {
+      for (k = 0; k < dc_trellis_candidates; k++) {
         int delta;
         int dc_delta;
         float bits;
         int m;
         int v2;
         
-        dc_candidate[k][bi] = qval - DC_TRELLIS_CANDIDATES/2 + k;
+        dc_candidate[k][bi] = qval - dc_trellis_candidates/2 + k;
         delta = dc_candidate[k][bi] * q - x;
         dc_candidate_dist = delta * delta * lambda_dc;
         dc_candidate[k][bi] *= 1 + 2*sign;
@@ -1390,7 +1400,7 @@ quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_bloc
         }
         
         /* loop of candidates from previous block */
-        for (l = 0; l < (bi == 0 ? 1 : DC_TRELLIS_CANDIDATES); l++) {
+        for (l = 0; l < (bi == 0 ? 1 : dc_trellis_candidates); l++) {
           int dc_pred = (bi == 0 ? *last_dc_val : dc_candidate[l][bi-1]);
           int updated_dc_context = 0;
           int st = (bi == 0) ? 0 : dc_context[l][bi-1];
@@ -1576,7 +1586,7 @@ quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_bloc
   
   if (cinfo->master->trellis_quant_dc) {
     j = 0;
-    for (i = 1; i < DC_TRELLIS_CANDIDATES; i++) {
+    for (i = 1; i < dc_trellis_candidates; i++) {
       if (accumulated_dc_cost[i][num_blocks-1] < accumulated_dc_cost[j][num_blocks-1])
         j = i;
     }
@@ -1588,7 +1598,7 @@ quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_bloc
     /* Save DC predictor */
     *last_dc_val = coef_blocks[num_blocks-1][0];
     
-    for (i = 0; i < DC_TRELLIS_CANDIDATES; i++) {
+    for (i = 0; i < dc_trellis_candidates; i++) {
       free(accumulated_dc_cost[i]);
       free(dc_cost_backtrack[i]);
       free(dc_candidate[i]);


### PR DESCRIPTION
When quality is high DC trellis is very subtle, because it becomes limited by lack of options to explore, rather than the lambda parameters.

I've made number of DC candidates dynamic, and increased when quality is high (in lower qualities it doesn't make sense to add candidates since DC is too coarse anyway). 

It makes compression 8% slower at high qualities.

Formula for number of candidates is fudged — I suspect it could be calculated better by taking `lambda_log_scale` into account (to exactly cover the range allowed by the lambda parameter), but even a simple one works for me.
