### PR TITLE
Add pkg-config requirement to documentation

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -7,6 +7,7 @@
 Build Requirements
 ==================
 
+-- pkg-config
 -- autoconf 2.56 or later
 -- automake 1.7 or later
 -- libtool 1.4 or later


### PR DESCRIPTION
As I discovered, pkg-config is required to install from master. 

Related to issue #99 
