### PR TITLE
Expose MOZJPEG_VERSION in jconfig.h header file

### DIFF
--- a/jconfig.h.in
+++ b/jconfig.h.in
@@ -3,8 +3,8 @@
  */
 #define JPEG_LIB_VERSION  62	/* Version 6b */
 
-/* libjpeg-turbo version */
-#define LIBJPEG_TURBO_VERSION 0
+/* mozjpeg version */
+#define MOZJPEG_VERSION 0
 
 /* Support arithmetic encoding */
 #undef C_ARITH_CODING_SUPPORTED


### PR DESCRIPTION
Hello, 

This PR allows code that relies on either mozjpeg or libjpeg-turbo to detect which is present via `#if` preprocessors statements.

The relevant history of `MOZJPEG_VERSION` in the related `configure.ac` is commit https://github.com/mozilla/mozjpeg/commit/c0aa2c01b71d52934040dad6f1890d8233cadae9 that rebranded from `LIBJPEG_TURBO_VERSION` to `LIBMOZJPEG_VERSION` then commit https://github.com/mozilla/mozjpeg/commit/4618c247dfe29aa9524d829d7a211e9baab65180 that changed from `LIBMOZJPEG_VERSION` to `MOZJPEG_VERSION`.

Cheers,
Lovell
