### PR TITLE
jpegtran: Do not leak the input and output buffers

### DIFF
--- a/jpegtran.c
+++ b/jpegtran.c
@@ -624,6 +624,9 @@ main (int argc, char **argv)
   end_progress_monitor((j_common_ptr) &dstinfo);
 #endif
 
+  free(inbuffer);
+  free(outbuffer);
+
   /* All done. */
   exit(jsrcerr.num_warnings + jdsterr.num_warnings ?EXIT_WARNING:EXIT_SUCCESS);
   return 0;                     /* suppress no-return-value warnings */


### PR DESCRIPTION
As spotted by Valgrind.