### PR TITLE
yuvjpeg: fix memory leak when @image_buffer allocation fails

### DIFF
--- a/yuvjpeg.c
+++ b/yuvjpeg.c
@@ -196,6 +196,7 @@ int main(int argc, char *argv[]) {
   image_buffer =
    malloc(frame_width*frame_height + 2*(frame_width/2)*(frame_height/2));
   if (!image_buffer) {
+    free(yuv_buffer);
     fprintf(stderr, "Memory allocation failure!\n");
     return 1;
   }


### PR DESCRIPTION
Make sure @yuv_buffer is freed before return.

Signed-off-by: Arjun Sreedharan <arjun024@gmail.com>