### PR TITLE
Per block lambda tuning

### DIFF
--- a/jcapimin.c
+++ b/jcapimin.c
@@ -25,6 +25,9 @@
 #include "jmemsys.h"
 #include "jcmaster.h"
 
+LOCAL(float) jpeg_no_op_lambda(void *user_data, jpeg_component_info *compptr, JBLOCK block, JDIMENSION block_col, JDIMENSION block_row, int coef_index_natural_order, float lambda) {
+  return lambda;
+}
 
 /*
  * Initialization of a JPEG compression object.
@@ -102,6 +105,7 @@ jpeg_CreateCompress (j_compress_ptr cinfo, int version, size_t structsize)
                                   sizeof(my_comp_master));
   MEMZERO(cinfo->master, sizeof(my_comp_master));
 
+  cinfo->master->lambda = jpeg_no_op_lambda;
   cinfo->master->compress_profile = JCP_MAX_COMPRESSION;
 }
 

--- a/jcapistd.c
+++ b/jcapistd.c
@@ -166,3 +166,8 @@ jpeg_write_raw_data (j_compress_ptr cinfo, JSAMPIMAGE data,
   cinfo->next_scanline += lines_per_iMCU_row;
   return lines_per_iMCU_row;
 }
+
+GLOBAL(void) jpeg_set_trellis_lambda_callback(const j_compress_ptr cinfo, jpeg_lambda_callback *callback, void *user_data) {
+  cinfo->master->lambda = callback;
+  cinfo->master->lambda_user_data = user_data;
+}

--- a/jccoefct.c
+++ b/jccoefct.c
@@ -416,20 +416,21 @@ compress_trellis_pass (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
      * on forward_DCT processes a complete horizontal row of DCT blocks.
      */
     for (block_row = 0; block_row < block_rows; block_row++) {
+      int row_num = block_row + coef->iMCU_row_num * compptr->v_samp_factor;
       thisblockrow = buffer[block_row];
       lastblockrow = (block_row > 0) ? buffer[block_row-1] : NULL;
 #ifdef C_ARITH_CODING_SUPPORTED
       if (cinfo->arith_code)
-        quantize_trellis_arith(cinfo, arith_r, thisblockrow,
-                               buffer_dst[block_row], blocks_across,
+        quantize_trellis_arith(cinfo, compptr, arith_r, thisblockrow,
+                               buffer_dst[block_row], blocks_across, row_num,
                                cinfo->quant_tbl_ptrs[compptr->quant_tbl_no],
                                cinfo->master->norm_src[compptr->quant_tbl_no],
                                cinfo->master->norm_coef[compptr->quant_tbl_no],
                                &lastDC, lastblockrow, buffer_dst[block_row-1]);
       else
 #endif
-        quantize_trellis(cinfo, dctbl, actbl, thisblockrow,
-                         buffer_dst[block_row], blocks_across,
+        quantize_trellis(cinfo, compptr, dctbl, actbl, thisblockrow,
+                         buffer_dst[block_row], blocks_across, row_num,
                          cinfo->quant_tbl_ptrs[compptr->quant_tbl_no],
                          cinfo->master->norm_src[compptr->quant_tbl_no],
                          cinfo->master->norm_coef[compptr->quant_tbl_no],

--- a/jcdctmgr.c
+++ b/jcdctmgr.c
@@ -905,7 +905,7 @@ LOCAL(int) get_num_dc_trellis_candidates(int dc_quantval) {
 }
 
 GLOBAL(void)
-quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actbl, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks,
+quantize_trellis(j_compress_ptr cinfo, jpeg_component_info *compptr, c_derived_tbl *dctbl, c_derived_tbl *actbl, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks, JDIMENSION row_num,
                  JQUANT_TBL * qtbl, double *norm_src, double *norm_coef, JCOEF *last_dc_val,
                  JBLOCKROW coef_blocks_above, JBLOCKROW src_above)
 {
@@ -1300,7 +1300,7 @@ quantize_trellis(j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actb
 
 #ifdef C_ARITH_CODING_SUPPORTED
 GLOBAL(void)
-quantize_trellis_arith(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks,
+quantize_trellis_arith(j_compress_ptr cinfo, jpeg_component_info *compptr, arith_rates *r, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks, JDIMENSION row_num,
                  JQUANT_TBL * qtbl, double *norm_src, double *norm_coef, JCOEF *last_dc_val,
                  JBLOCKROW coef_blocks_above, JBLOCKROW src_above)
 {

--- a/jcdctmgr.c
+++ b/jcdctmgr.c
@@ -993,21 +993,21 @@ quantize_trellis(j_compress_ptr cinfo, jpeg_component_info *compptr, c_derived_t
     lambda_base = 1.0 / norm;
   
   for (bi = 0; bi < num_blocks; bi++) {
-    
+
     norm = 0.0;
     for (i = 1; i < DCTSIZE2; i++) {
       norm += src[bi][i] * src[bi][i];
     }
     norm /= 63.0;
-    
+
     if (cinfo->master->lambda_log_scale2 > 0.0)
       lambda = pow(2.0, cinfo->master->lambda_log_scale1) * lambda_base /
                    (pow(2.0, cinfo->master->lambda_log_scale2) + norm);
     else
       lambda = pow(2.0, cinfo->master->lambda_log_scale1 - 12.0) * lambda_base;
-    
-    lambda_dc = lambda * lambda_tbl[0];
-    
+
+    lambda_dc = cinfo->master->lambda(cinfo->master->lambda_user_data, compptr, src[bi], bi, row_num, 0, lambda * lambda_tbl[0]);
+
     accumulated_zero_dist[Ss-1] = 0.0;
     accumulated_cost[Ss-1] = 0.0;
 
@@ -1090,6 +1090,7 @@ quantize_trellis(j_compress_ptr cinfo, jpeg_component_info *compptr, c_derived_t
     /* Do AC coefficients */
     for (i = Ss; i <= Se; i++) {
       int z = jpeg_natural_order[i];
+      float lambda_ac = cinfo->master->lambda(cinfo->master->lambda_user_data, compptr, src[bi], bi, row_num, i, lambda * lambda_tbl[z]);
 
       int sign = src[bi][z] >> 31;
       int x = abs(src[bi][z]);
@@ -1099,9 +1100,9 @@ quantize_trellis(j_compress_ptr cinfo, jpeg_component_info *compptr, c_derived_t
       float candidate_dist[16];
       int num_candidates;
       int qval;
-      
-      accumulated_zero_dist[i] = x * x * lambda * lambda_tbl[z] + accumulated_zero_dist[i-1];
-      
+
+      accumulated_zero_dist[i] = x * x * lambda_ac + accumulated_zero_dist[i-1];
+
       qval = (x + q/2) / q; /* quantized value (round nearest) */
 
       if (qval == 0) {
@@ -1380,9 +1381,9 @@ quantize_trellis_arith(j_compress_ptr cinfo, jpeg_component_info *compptr, arith
       (pow(2.0, cinfo->master->lambda_log_scale2) + norm);
     else
       lambda = pow(2.0, cinfo->master->lambda_log_scale1 - 12.0) * lambda_base;
-    
-    lambda_dc = lambda * lambda_tbl[0];
-    
+
+    lambda_dc = cinfo->master->lambda(cinfo->master->lambda_user_data, compptr, src[bi], bi, row_num, 0, lambda * lambda_tbl[0]);
+
     accumulated_zero_dist[Ss-1] = 0.0;
     accumulated_cost[Ss-1] = 0.0;
     
@@ -1483,7 +1484,8 @@ quantize_trellis_arith(j_compress_ptr cinfo, jpeg_component_info *compptr, arith
     /* Do AC coefficients */
     for (i = Ss; i <= Se; i++) {
       int z = jpeg_natural_order[i];
-      
+      float lambda_ac = cinfo->master->lambda(cinfo->master->lambda_user_data, compptr, src[bi], bi, row_num, i, lambda * lambda_tbl[z]);
+
       int sign = src[bi][z] >> 31;
       int x = abs(src[bi][z]);
       int q = 8 * qtbl->quantval[z];
@@ -1492,9 +1494,9 @@ quantize_trellis_arith(j_compress_ptr cinfo, jpeg_component_info *compptr, arith
       int num_candidates;
       int qval;
       int delta;
-      
-      accumulated_zero_dist[i] = x * x * lambda * lambda_tbl[z] + accumulated_zero_dist[i-1];
-      
+
+      accumulated_zero_dist[i] = x * x * lambda_ac + accumulated_zero_dist[i-1];
+
       qval = (x + q/2) / q; /* quantized value (round nearest) */
       
       if (qval == 0) {

--- a/jchuff.h
+++ b/jchuff.h
@@ -44,6 +44,6 @@ EXTERN(void) jpeg_gen_optimal_table
         (j_compress_ptr cinfo, JHUFF_TBL * htbl, long freq[]);
 
 EXTERN(void) quantize_trellis
-        (j_compress_ptr cinfo, c_derived_tbl *dctbl, c_derived_tbl *actbl, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks,
+        (j_compress_ptr cinfo, jpeg_component_info *compptr, c_derived_tbl *dctbl, c_derived_tbl *actbl, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks, JDIMENSION row_num,
                  JQUANT_TBL * qtbl, double *norm_src, double *norm_coef, JCOEF *last_dc_val,
          JBLOCKROW coef_blocks_above, JBLOCKROW src_above);

--- a/jpegint.h
+++ b/jpegint.h
@@ -395,7 +395,7 @@ EXTERN(void) jzero_far (void * target, size_t bytestozero);
 EXTERN(void) jget_arith_rates (j_compress_ptr cinfo, int dc_tbl_no, int ac_tbl_no, arith_rates *r);
 
 EXTERN(void) quantize_trellis_arith
-(j_compress_ptr cinfo, arith_rates *r, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks,
+(j_compress_ptr cinfo, jpeg_component_info *compptr, arith_rates *r, JBLOCKROW coef_blocks, JBLOCKROW src, JDIMENSION num_blocks, JDIMENSION row_num,
  JQUANT_TBL * qtbl, double *norm_src, double *norm_coef, JCOEF *last_dc_val,
  JBLOCKROW coef_blocks_above, JBLOCKROW src_above);
 #endif

--- a/jpegint.h
+++ b/jpegint.h
@@ -89,6 +89,9 @@ struct jpeg_comp_master {
   float lambda_log_scale2;
   
   float trellis_delta_dc_weight;
+
+  jpeg_lambda_callback *lambda;
+  void *lambda_user_data;
 };
 
 #ifdef C_ARITH_CODING_SUPPORTED

--- a/jpeglib.h
+++ b/jpeglib.h
@@ -1121,6 +1121,25 @@ EXTERN(void) jpeg_c_set_int_param (j_compress_ptr cinfo, J_INT_PARAM param,
 EXTERN(int) jpeg_c_get_int_param (const j_compress_ptr cinfo, J_INT_PARAM param);
 
 
+/**
+ * When trellis quantization is on, this function is consulted per coefficient
+ * to adjust lambda value. Lambda is a coefficient controlling tradeoff between
+ * file size and quality (higher values mean higher quality)
+ *
+ * @param  user_data   value from jpeg_set_trellis_lambda_callback, can be NULL
+ * @param  compptr     current component info
+ * @param  block       DCT coefficients
+ * @param  block_col   x coordinate of the current block
+ * @param  row_num     y coordinate of the current block
+ * @param  coef_index  index of the coefficient, in frequency order
+ * @param  lambda      default lambda value computed for this block
+ * @return             modified lambda value
+ */
+typedef float jpeg_lambda_callback(void *user_data, jpeg_component_info *compptr,
+  JBLOCK block, JDIMENSION block_col, JDIMENSION row_num, int coef_index, float lambda);
+EXTERN(void) jpeg_set_trellis_lambda_callback(const j_compress_ptr cinfo,
+  jpeg_lambda_callback *callback, void *user_data);
+
 /* These marker codes are exported since applications and data source modules
  * are likely to want to use them.
  */


### PR DESCRIPTION
Fixes #116

Instead of an array that defines quality upfront, it's a callback consulted for every coefficient of every block. This way the client application is free to use any data source for the quality without making any additional large arrays for the library.

I'm passing the old lambda value to the callback, so the callback can respect existing lambda tuning settings, and the simplest implementation can be without any math, e.g. if the JPEG is going to be used with an alpha mask it can be `return is_opaque(x,y) ? lambda : 0`.

And finally the tuning is per coefficient, so that client applications can control DC and AC sharpness separately.

I'm creating a new global symbol `jpeg_set_trellis_lambda_callback`, because there's no `jpeg_c_set_XX_param` for function pointers, and trellis is out of scope of vanilla libjpeg-turbo anyway.
