### PR TITLE
Produce 8-bit quantization tables in 8-bit precision files

### DIFF
--- a/cjpeg.c
+++ b/cjpeg.c
@@ -262,7 +262,7 @@ parse_switches (j_compress_ptr cinfo, int argc, char **argv,
 
   /* Set up default JPEG parameters. */
 
-  force_baseline = FALSE;       /* by default, allow 16-bit quantizers */
+  force_baseline = (BITS_IN_JSAMPLE == 8); /* 8-bit JPEG is supposed to only have 8-bit qtables (B.2.4.1) */
 #ifdef C_PROGRESSIVE_SUPPORTED
   simple_progressive = cinfo->num_scans == 0 ? FALSE : TRUE;
 #else


### PR DESCRIPTION
I've learned that quantization tables produced by cjpeg are [non-standard](http://www.digicamsoft.com/itu/itu-t81-44.html) (https://github.com/kaksmet/jpeg-decoder/issues/40), so here's the fix.
