### PR TITLE
Guess default chroma subsampling setting from the quality setting

### DIFF
--- a/cjpeg.c
+++ b/cjpeg.c
@@ -608,6 +608,8 @@ parse_switches (j_compress_ptr cinfo, int argc, char **argv,
       if (! set_quant_slots(cinfo, qslotsarg))
         usage();
 
+    /* set_quality_ratings sets default subsampling, so the explicit
+       subsampling must be set after it */
     if (samplearg != NULL)      /* process -sample if it was present */
       if (! set_sample_factors(cinfo, samplearg)) {
         fprintf(stderr, "%s: can't set sample factors\n", progname);

--- a/rdswitch.c
+++ b/rdswitch.c
@@ -553,6 +553,17 @@ set_quality_ratings (j_compress_ptr cinfo, char *arg, boolean force_baseline)
     }
   }
   jpeg_default_qtables(cinfo, force_baseline);
+
+  /* For some images chroma subsampling significantly degrades color quality,
+     making it impossible to achieve high visual quality regardless of quality setting.
+     To make the quality setting more intuitive, disable subsampling when high-quality
+     color is desired. */
+  if (val >= 90) {
+    set_sample_factors(cinfo, "1x1");
+  } else if (val >= 80) {
+    set_sample_factors(cinfo, "2x1");
+  }
+
   return TRUE;
 }
 


### PR DESCRIPTION
This change only affects the `cjpeg` tool. The C interface is unchanged.

Not all users may be aware of the chroma subsampling setting, so I think it's valuable to try to have a sensible default. That's what Photoshop and ImageMagick do already.

Since subsampling lowers color quality, it's unintuitive that even very high quality settings can produce low-quality images.

This change lowers subsampling for q >= 80, and disables subsampling for q >= 90. Explicit `-sample` argument overrides the default.

I'm not proposing upstreaming this to libjpeg-turbo, because that project treats `cjpeg` as a simple demo tool, and isn't interested in expanding it.