### PR TITLE
Calculate jpeg_simple_progression nscans correctly when dc_scan_opt_mode

### DIFF
--- a/jcparam.c
+++ b/jcparam.c
@@ -868,7 +868,13 @@ jpeg_simple_progression (j_compress_ptr cinfo)
   ncomps = cinfo->num_components;
   if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) {
     /* Custom script for YCbCr color images. */
-    nscans = 10;
+    if (cinfo->master->dc_scan_opt_mode == 0) {
+      nscans = 8;  /* 1 DC scan for all components */
+    } else if (cinfo->master->dc_scan_opt_mode == 1) {
+      nscans = 10; /* 1 DC scan for each component */
+    } else {
+      nscans = 9;  /* 1 DC scan for luminance and 1 DC scan for chroma */
+    }
   } else {
     /* All-purpose script for other color spaces. */
     if (cinfo->master->compress_profile == JCP_MAX_COMPRESSION) {
@@ -906,14 +912,16 @@ jpeg_simple_progression (j_compress_ptr cinfo)
     if (cinfo->master->compress_profile == JCP_MAX_COMPRESSION) {
       /* scan defined in jpeg_scan_rgb.txt in jpgcrush */
     /* Initial DC scan */
-      if (cinfo->master->dc_scan_opt_mode == 0)
+      if (cinfo->master->dc_scan_opt_mode == 0) {
+        /* 1 DC scan for all components */
         scanptr = fill_dc_scans(scanptr, ncomps, 0, 0);
-      else if (cinfo->master->dc_scan_opt_mode == 1) {
+      } else if (cinfo->master->dc_scan_opt_mode == 1) {
+        /* 1 DC scan for each component */
         scanptr = fill_a_scan(scanptr, 0, 0, 0, 0, 0);
         scanptr = fill_a_scan(scanptr, 1, 0, 0, 0, 0);
         scanptr = fill_a_scan(scanptr, 2, 0, 0, 0, 0);
-      }
-      else {
+      } else {
+        /* 1 DC scan for luminance and 1 DC scan for chroma */
         scanptr = fill_dc_scans(scanptr, 1, 0, 0);
         scanptr = fill_a_scan_pair(scanptr, 1, 0, 0, 0, 0);
       }


### PR DESCRIPTION
**Issue #249**

When disabling the scan optimization (e.g. `-fastcrush`) and setting a non-default DC scan option (e.g. `-dc_scan_opt 0`) the library will end in an error state. This is due to the total number of scans (`nscans`) not being set correctly.

Alternatively, this "bad configuration" can be achieved using the following configuration lines in code:

```
jpeg_c_set_bool_param(cinfo, JBOOLEAN_OPTIMIZE_SCANS, FALSE);
jpeg_c_set_int_param(cinfo, JINT_DC_SCAN_OPT_MODE, 0);
```

**Fix**

Update code that calculates the number of scans correctly. The total number of scans is 10 when splitting up all components (default, `-dc-scan-opt 1`) and 8 when merging all components (`-dc-scan-opt 0`). For `-fastcrush` and `-dc_scan_opt 2` the MozJpeg creates one scan for luma and one for both chroma components resulting in 9 scans. (Notice: this never matched the documentation, as the documentation only refers to the meaning of this option when scan optimization is enabled).

**Test plan**

I've run cjpeg before and after the change. I've verified that JPEGs without `-fastcrush` are not changing (`shasum` is constant). For the parameter combination above we can see an errors/wrong scan numbers before the change. After the change, MozJpeg creates correct output.

Before:

```java
[user:mozjpeg]$ ./cjpeg testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
552e9e6b2c5ff8bf8a92d31c4a149a202da319ef  /tmp/j.jpg
       7

[user:mozjpeg]$ ./cjpeg -dc-scan-opt 0 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
3cb977b11fb9c282f1f75dbdded6afc1fd75497c  /tmp/j.jpg
       5

[user:mozjpeg]$ ./cjpeg -dc-scan-opt 1 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
552e9e6b2c5ff8bf8a92d31c4a149a202da319ef  /tmp/j.jpg
       7

[user:mozjpeg]$ ./cjpeg -dc-scan-opt 2 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
61c03cec6ef5558afa916c8734c049edb43618ce  /tmp/j.jpg
       6

[user:mozjpeg]$ ./cjpeg -fastcrush -dc-scan-opt 0 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
Invalid progressive parameters at scan script entry 10

[user:mozjpeg]$ ./cjpeg -fastcrush -dc-scan-opt 1 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
a940f91433c11d62e2a5933faba7087ed33c73c1  /tmp/j.jpg
      10

[user:mozjpeg]$ ./cjpeg -fastcrush -dc-scan-opt 2 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
c56f13219f8c8ab5539293846653faef91ad6bc5  /tmp/j.jpg
      10
```

After:

```java
[user:mozjpeg]$ ./cjpeg testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
552e9e6b2c5ff8bf8a92d31c4a149a202da319ef  /tmp/j.jpg
       7

[user:mozjpeg]$ ./cjpeg -dc-scan-opt 0 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
3cb977b11fb9c282f1f75dbdded6afc1fd75497c  /tmp/j.jpg
       5

[user:mozjpeg]$ ./cjpeg -dc-scan-opt 1 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
552e9e6b2c5ff8bf8a92d31c4a149a202da319ef  /tmp/j.jpg
       7

[user:mozjpeg]$ ./cjpeg -dc-scan-opt 2 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
61c03cec6ef5558afa916c8734c049edb43618ce  /tmp/j.jpg
       6

[user:mozjpeg]$ ./cjpeg -fastcrush -dc-scan-opt 0 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
27a27c9289c327c7538c04574e31ad91131fe186  /tmp/j.jpg
       8

[user:mozjpeg]$ ./cjpeg -fastcrush -dc-scan-opt 1 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
a940f91433c11d62e2a5933faba7087ed33c73c1  /tmp/j.jpg
      10

[user:mozjpeg]$ ./cjpeg -fastcrush -dc-scan-opt 2 testimages/testorig.ppm > /tmp/j.jpg && shasum /tmp/j.jpg && exiftool -v3 /tmp/j.jpg | grep -e SOS | wc -l
5a80928259efbbff216be3271ab30cbe9541b8a2  /tmp/j.jpg
       9
```

Regression tests:

```
[user:mozjpeg]$ make test
rm -f testout*
rm -f *_GRAY_*.bmp

...

./jpegtran -revert -crop 120x90+20+50 -transpose -perfect -outfile testout_crop.jpg ./testimages/testorig.jpg
md5/md5cmp b4197f377e621c4e9b1d20471432610d testout_crop.jpg
testout_crop.jpg: OK
rm -f testout_crop.jpg
echo GREAT SUCCESS!
GREAT SUCCESS!
[user:mozjpeg]$ 
```

**Let me know if there are any other test cases you'd like to have covered**