### PR TITLE
Preserve ICC profile when converting from PNG

### DIFF
--- a/cderror.h
+++ b/cderror.h
@@ -126,6 +126,7 @@ JMESSAGE(JERR_UNSUPPORTED_FORMAT, "Unsupported output file format")
 
 #ifdef PNG_SUPPORTED
 JMESSAGE(JERR_PNG_ERROR, "Unable to read PNG file: %s")
+JMESSAGE(JERR_PNG_PROFILETOOLARGE, "Embedded profile was too large for this tool - dropped.")
 #endif
 
 #ifdef JMAKE_ENUM_LIST

--- a/cjpeg.c
+++ b/cjpeg.c
@@ -81,6 +81,7 @@ static const char * const cdjpeg_message_table[] = {
 
 static boolean is_targa;        /* records user -targa switch */
 static boolean is_jpeg;
+static boolean copy_markers;
 
 LOCAL(cjpeg_source_ptr)
 select_file_type (j_compress_ptr cinfo, FILE *infile)
@@ -115,6 +116,7 @@ select_file_type (j_compress_ptr cinfo, FILE *infile)
 #endif
 #ifdef PNG_SUPPORTED
   case 0x89:
+    copy_markers = TRUE;
     return jinit_read_png(cinfo);
 #endif
 #ifdef RLE_SUPPORTED
@@ -127,6 +129,7 @@ select_file_type (j_compress_ptr cinfo, FILE *infile)
 #endif
   case 0xff:
     is_jpeg = TRUE;
+    copy_markers = TRUE;
     return jinit_read_jpeg(cinfo);
   default:
     ERREXIT(cinfo, JERR_UNKNOWN_FORMAT);
@@ -766,7 +769,7 @@ main (int argc, char **argv)
   jpeg_start_compress(&cinfo, TRUE);
 
   /* Copy metadata */
-  if (is_jpeg) {
+  if (copy_markers) {
     jpeg_saved_marker_ptr marker;
     
     /* In the current implementation, we don't actually need to examine the

--- a/rdpng.c
+++ b/rdpng.c
@@ -69,6 +69,11 @@ start_input_png (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
     png_get_IHDR(source->png_ptr, source->info_ptr, &width, &height,
                  &bit_depth, &color_type, NULL, NULL, NULL);
 
+    if (width > 65535 || height > 65535) {
+        ERREXITS(cinfo, JERR_PNG_ERROR, "Image too large");
+        return;
+    }
+
     if (color_type == PNG_COLOR_TYPE_GRAY) {
         cinfo->in_color_space = JCS_GRAYSCALE;
         cinfo->input_components = 1;
@@ -77,8 +82,9 @@ start_input_png (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
         cinfo->input_components = 3;
     }
 
-    if (bit_depth == 16)
+    if (bit_depth == 16) {
         png_set_strip_16(source->png_ptr);
+    }
 
     cinfo->data_precision = 8;
     cinfo->image_width = width;

--- a/rdpng.c
+++ b/rdpng.c
@@ -74,7 +74,7 @@ start_input_png (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
         return;
     }
 
-    if (color_type == PNG_COLOR_TYPE_GRAY) {
+    if (color_type == PNG_COLOR_TYPE_GRAY || color_type == PNG_COLOR_TYPE_GRAY_ALPHA) {
         cinfo->in_color_space = JCS_GRAYSCALE;
         cinfo->input_components = 1;
     } else {


### PR DESCRIPTION
Caveats:

* Outdated libpng (1.2) will show a warning about char<>byte mismatch, but the warning can be safely ignored.
* Drops profiles larger than 64KB. Partly because I was too lazy to support split chunks, partly because such large profiles are likely to be undesirable bloat.
