### PR TITLE
Calculate jpeg_simple_progression nscans correctly

### DIFF
--- a/jcparam.c
+++ b/jcparam.c
@@ -864,16 +864,20 @@ jpeg_simple_progression (j_compress_ptr cinfo)
   if (cinfo->global_state != CSTATE_START)
     ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
 
-  /* Figure space needed for script.  Calculation must match code below! */
+  /* Figure space needed for script. Calculation must match code below! */
   ncomps = cinfo->num_components;
   if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) {
     /* Custom script for YCbCr color images. */
-    if (cinfo->master->dc_scan_opt_mode == 0) {
-      nscans = 8;  /* 1 DC scan for all components */
-    } else if (cinfo->master->dc_scan_opt_mode == 1) {
-      nscans = 10; /* 1 DC scan for each component */
+    if (cinfo->master->compress_profile == JCP_MAX_COMPRESSION) {
+      if (cinfo->master->dc_scan_opt_mode == 0) {
+        nscans = 9;  /* 1 DC scan for all components */
+      } else if (cinfo->master->dc_scan_opt_mode == 1) {
+        nscans = 11; /* 1 DC scan for each component */
+      } else {
+        nscans = 10; /* 1 DC scan for luminance and 1 DC scan for chroma */
+      }
     } else {
-      nscans = 9;  /* 1 DC scan for luminance and 1 DC scan for chroma */
+      nscans = 10;   /* 2 DC scans and 8 AC scans */
     }
   } else {
     /* All-purpose script for other color spaces. */


### PR DESCRIPTION
Unfortunately, my previous pull-request https://github.com/mozilla/mozjpeg/pull/251 was not complete. While it resolved the crashes, the encoded file would miss the last scan in the output when using the option `-fastcrush`.

Also, it did not cover the `else` branch which can cause a crash (only triggered with options `-revert -progressive`).

The root cause was that I expected the existing `nscans = 10` (before the previous PR) to be correct for `dc-scan-opt=1` (default value). However, that number was already off-by-one (should have been 11). As a result, all numbers in that PR are also off-by-one (I only changed them relative to that 10).

**Fix**

I've manually counted the `fill_a_scan` in the lines below twice to make sure they are actually correct. There are 1, 3 or 2 DC scans plus 8 AC scans.

Also, I've added the correct `nscans` for the `else` branch.

**Testplan**

I've run cjpeg on `original.jpeg` before and after this change:

Before:

```
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -fastcrush -dc-scan-opt 0 original.jpg > before_moz_opt_0.jpg
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -fastcrush -dc-scan-opt 1 original.jpg > before_moz_opt_1.jpg
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -fastcrush -dc-scan-opt 2 original.jpg > before_moz_opt_2.jpg
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -revert -progressive original.jpg > before_moz_jcp_fast.jpg
Invalid progressive parameters at scan script entry 11

[user:Desktop]$ ls -la before*
-rw-r--r--    1 user  group   4007399 Jun 29 16:36 before_moz_opt_0.jpg
-rw-r--r--    1 user  group   4006888 Jun 29 16:36 before_moz_opt_1.jpg
-rw-r--r--    1 user  group   4007502 Jun 29 16:36 before_moz_opt_2.jpg
-rw-r--r--    1 user  group         0 Jun 30 09:28 before_moz_revert_progressive.jpg

[user:Desktop]$ exiftool -v5 before_moz_opt_0.jpg | grep SOS | wc -l
       8
[user:Desktop]$ exiftool -v5 before_moz_opt_1.jpg | grep SOS | wc -l
      10
[user:Desktop]$ exiftool -v5 before_moz_opt_2.jpg | grep SOS | wc -l
       9
```

After:

```
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -fastcrush -dc-scan-opt 2 original.jpg > fix_moz_opt_2.jpg
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -fastcrush -dc-scan-opt 1 original.jpg > fix_moz_opt_1.jpg
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -fastcrush -dc-scan-opt 0 original.jpg > fix_moz_opt_0.jpg
[user:Desktop]$ ~/mozjpeg/cjpeg -quality 90 -revert -progressive original.jpg > fix_moz_jcp_fast.jpg

[user:Desktop]$ ls -la fix*
-rw-r--r--    1 user  group   4063351 Jun 29 16:37 fix_moz_opt_0.jpg
-rw-r--r--    1 user  group   4062840 Jun 29 16:37 fix_moz_opt_1.jpg
-rw-r--r--    1 user  group   4063454 Jun 29 16:36 fix_moz_opt_2.jpg
-rw-r--r--    1 user  group   4407372 Jun 30 09:28 fix_moz_jcp_fast.jpg

[user:Desktop]$ exiftool -v5 fix_moz_opt_0.jpg | grep SOS | wc -l
       9
[user:Desktop]$ exiftool -v5 fix_moz_opt_1.jpg | grep SOS | wc -l
      11
[user:Desktop]$ exiftool -v5 fix_moz_opt_2.jpg | grep SOS | wc -l
      10
[user:Desktop]$ exiftool -v5 fix_moz_jcp_fast.jpg | grep SOS | wc -l
      10
```

Regression testing:

```
[user:mozjpeg]$ autoreconf -fiv
[user:mozjpeg]$ ./configure
[user:mozjpeg]$ make
[user:mozjpeg]$ make test
...
echo GREAT SUCCESS!
GREAT SUCCESS!
```

Let me know if there are any other cases that I should cover here.