### PR TITLE
Add optional PNG support to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,11 @@ else()
   set(COMPILE_FLAGS "-DBMP_SUPPORTED -DGIF_SUPPORTED -DPPM_SUPPORTED -DTARGA_SUPPORTED -DUSE_SETMODE")
   set(CJPEG_BMP_SOURCES rdbmp.c rdtarga.c)
   set(DJPEG_BMP_SOURCES wrbmp.c wrtarga.c)
+
+  if(PNG_SUPPORTED)
+    set(COMPILE_FLAGS ${COMPILE_FLAGS} -DPNG_SUPPORTED)
+    set(CJPEG_BMP_SOURCES ${CJPG_BMP_SOURCES} rdpng.c)
+  endif()
 endif()
 
 if(ENABLE_STATIC)
@@ -305,6 +310,14 @@ if(ENABLE_STATIC)
     ${CJPEG_BMP_SOURCES})
   set_property(TARGET cjpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
   target_link_libraries(cjpeg-static jpeg-static)
+
+  if(PNG_SUPPORTED)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+    find_package(PNG 1.6 REQUIRED)
+    find_package(ZLIB REQUIRED)
+    target_include_directories(cjpeg-static PUBLIC ${PNG_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
+    target_link_libraries(cjpeg-static ${PNG_LIBRARY} ${ZLIB_LIBRARY})
+  endif()
 
   add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrgif.c
     wrppm.c ${DJPEG_BMP_SOURCES})


### PR DESCRIPTION
This allows for `-DPNG_SUPPORTED=ON` to be specified on the cmake command line.

For Visual Studio, with `vcpkg` for installing libpng:
```
vcpkg install libpng:x64-windows-static
cmake -A x64 .. -DPNG_SUPPORTED=ON -DCMAKE_TOOLCHAIN_FILE=c:/PATH/TO/vcpkg/scri pts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static
cmake --build . -- -p:Configuration=Release
```
