### PR TITLE
Fixing compiler warning -Wmissing-prototypes

### DIFF
--- a/jdatadst.c
+++ b/jdatadst.c
@@ -22,6 +22,7 @@
 #include "jinclude.h"
 #include "jpeglib.h"
 #include "jerror.h"
+#include "jpegint.h"
 
 #ifndef HAVE_STDLIB_H           /* <stdlib.h> should declare malloc(),free() */
 extern void *malloc (size_t size);


### PR DESCRIPTION
jdatadst.c:252:1: warning: no previous prototype for function 'jpeg_mem_dest_internal' [-Wmissing-prototypes]

This should be a non-functional change. 