### PR TITLE
Prefer smallest of input,output pair only on non-image changing ops

### DIFF
--- a/jpegtran.c
+++ b/jpegtran.c
@@ -589,7 +589,8 @@ main (int argc, char **argv)
 
   /* Finish compression and release memory */
   jpeg_finish_compress(&dstinfo);
-  
+
+#if JPEG_LIB_VERSION >= 80 || defined(MEM_SRCDST_SUPPORTED)
   if (jpeg_c_int_param_supported(&dstinfo, JINT_COMPRESS_PROFILE) &&
       jpeg_c_get_int_param(&dstinfo, JINT_COMPRESS_PROFILE)
         == JCP_MAX_COMPRESSION) {
@@ -611,6 +612,7 @@ main (int argc, char **argv)
         fprintf(stderr, "%s: can't write to stdout\n", progname);
     }
   }
+#endif
     
   jpeg_destroy_compress(&dstinfo);
   (void) jpeg_finish_decompress(&srcinfo);


### PR DESCRIPTION
Fixes #296. Possibly fixes #221 and #174.
First commit unrelated to switch, but the whole block is only working when ifdef condition met, since few lines above `jpeg_mem_dest` is only used when ifded is true
https://github.com/mozilla/mozjpeg/blob/7678cba14037c9381119df6c6452e18f70ccb327/jpegtran.c#L568-L572

~~Second commit is for actual fix of #296. I was first going to add an internal flag to `parse_swtiches` routine, but realized that there are almost all of the switches might cause output to be bigger. So new switch looks reasonable.~~

I made it so current mozjpeg's jpegtran behavior is reverted and matches libjpeg-turbo behavior. This might be considered as BC break, but I've read somewhere that cli tools for mozjpeg is not a priority and complimentary. All of which makes me think such break is acceptable. Will be happy to reverse it back, if there is an opposition. 