### PR TITLE
Fix errors while build rpm package (CentOS 7.x)

### DIFF
--- a/release/mozjpeg.spec.in
+++ b/release/mozjpeg.spec.in
@@ -8,7 +8,7 @@
 %define _datadir %{__datadir}
 
 # Path under which docs should be installed
-%define _docdir /usr/share/doc/%{name}-%{version}
+%define _docdir /opt/mozjpeg/doc/%{name}-%{version}
 
 # Path under which headers should be installed
 %define _includedir %{__includedir}
@@ -45,7 +45,7 @@ Group: System Environment/Libraries
 Release: @BUILD@
 License: BSD-style
 BuildRoot: %{_blddir}/%{name}-buildroot-%{version}-%{release}
-Prereq: /sbin/ldconfig
+Requires(pre,preun): /sbin/ldconfig
 %if "%{_bits}" == "64"
 Provides: %{name} = %{version}-%{release}, @PACKAGE_NAME@ = %{version}-%{release}, libturbojpeg.so()(64bit)
 %else


### PR DESCRIPTION
Fix #272
```
… Tons of text…
+ umask 022
+ cd /tmp/mozjpeg-build.0o3z2b/BUILD
+ rm -rf /tmp/mozjpeg-build.0o3z2b/BUILDROOT/mozjpeg-3.3.1-20181012.x86_64
+ exit 0```