### PR TITLE
Adds support for cocoapods

### DIFF
--- a/jdcoefct.c
+++ b/jdcoefct.c
@@ -605,7 +605,7 @@ decompress_smooth_data (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
         DC1 = DC2; DC2 = DC3;
         DC4 = DC5; DC5 = DC6;
         DC7 = DC8; DC8 = DC9;
-        buffer_ptr++, prev_block_row++, next_block_row++;
+        buffer_ptr++; prev_block_row++; next_block_row++;
         output_col += compptr->_DCT_scaled_size;
       }
       output_ptr += compptr->_DCT_scaled_size;

--- a/jdcol565.c
+++ b/jdcol565.c
@@ -76,7 +76,7 @@ ycc_rgb565_convert_internal (j_decompress_ptr cinfo,
       b = range_limit[y + Cbbtab[cb]];
       rgb = PACK_TWO_PIXELS(rgb, PACK_SHORT_565(r, g, b));
 
-      WRITE_TWO_ALIGNED_PIXELS(outptr, rgb);
+      WRITE_TWO_ALIGNED_PIXELS(outptr, (int)rgb);
       outptr += 4;
     }
     if (num_cols & 1) {
@@ -161,7 +161,7 @@ ycc_rgb565D_convert_internal (j_decompress_ptr cinfo,
       d0 = DITHER_ROTATE(d0);
       rgb = PACK_TWO_PIXELS(rgb, PACK_SHORT_565(r, g, b));
 
-      WRITE_TWO_ALIGNED_PIXELS(outptr, rgb);
+      WRITE_TWO_ALIGNED_PIXELS(outptr, (int)rgb);
       outptr += 4;
     }
     if (num_cols & 1) {
@@ -221,7 +221,7 @@ rgb_rgb565_convert_internal (j_decompress_ptr cinfo,
       b = GETJSAMPLE(*inptr2++);
       rgb = PACK_TWO_PIXELS(rgb, PACK_SHORT_565(r, g, b));
 
-      WRITE_TWO_ALIGNED_PIXELS(outptr, rgb);
+      WRITE_TWO_ALIGNED_PIXELS(outptr, (int)rgb);
       outptr += 4;
     }
     if (num_cols & 1) {
@@ -280,7 +280,7 @@ rgb_rgb565D_convert_internal (j_decompress_ptr cinfo,
       d0 = DITHER_ROTATE(d0);
       rgb = PACK_TWO_PIXELS(rgb, PACK_SHORT_565(r, g, b));
 
-      WRITE_TWO_ALIGNED_PIXELS(outptr, rgb);
+      WRITE_TWO_ALIGNED_PIXELS(outptr, (int)rgb);
       outptr += 4;
     }
     if (num_cols & 1) {
@@ -322,7 +322,7 @@ gray_rgb565_convert_internal (j_decompress_ptr cinfo,
       rgb = PACK_SHORT_565(g, g, g);
       g = *inptr++;
       rgb = PACK_TWO_PIXELS(rgb, PACK_SHORT_565(g, g, g));
-      WRITE_TWO_ALIGNED_PIXELS(outptr, rgb);
+      WRITE_TWO_ALIGNED_PIXELS(outptr, (int)rgb);
       outptr += 4;
     }
     if (num_cols & 1) {
@@ -371,7 +371,7 @@ gray_rgb565D_convert_internal (j_decompress_ptr cinfo,
       rgb = PACK_TWO_PIXELS(rgb, PACK_SHORT_565(g, g, g));
       d0 = DITHER_ROTATE(d0);
 
-      WRITE_TWO_ALIGNED_PIXELS(outptr, rgb);
+      WRITE_TWO_ALIGNED_PIXELS(outptr, (int)rgb);
       outptr += 4;
     }
     if (num_cols & 1) {

--- a/jidctint.c
+++ b/jidctint.c
@@ -208,8 +208,8 @@ jpeg_idct_islow (j_decompress_ptr cinfo, jpeg_component_info *compptr,
         inptr[DCTSIZE*5] == 0 && inptr[DCTSIZE*6] == 0 &&
         inptr[DCTSIZE*7] == 0) {
       /* AC terms all zero */
-      int dcval = LEFT_SHIFT(DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]),
-                             PASS1_BITS);
+      int dcval = (int)LEFT_SHIFT(DEQUANTIZE(inptr[DCTSIZE*0],
+                                  quantptr[DCTSIZE*0]), PASS1_BITS);
 
       wsptr[DCTSIZE*0] = dcval;
       wsptr[DCTSIZE*1] = dcval;

--- a/jidctred.c
+++ b/jidctred.c
@@ -146,8 +146,8 @@ jpeg_idct_4x4 (j_decompress_ptr cinfo, jpeg_component_info *compptr,
         inptr[DCTSIZE*3] == 0 && inptr[DCTSIZE*5] == 0 &&
         inptr[DCTSIZE*6] == 0 && inptr[DCTSIZE*7] == 0) {
       /* AC terms all zero; we need not examine term 4 for 4x4 output */
-      int dcval = LEFT_SHIFT(DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]),
-                             PASS1_BITS);
+      int dcval = (int)LEFT_SHIFT(DEQUANTIZE(inptr[DCTSIZE*0],
+                                  quantptr[DCTSIZE*0]), PASS1_BITS);
 
       wsptr[DCTSIZE*0] = dcval;
       wsptr[DCTSIZE*1] = dcval;
@@ -298,8 +298,8 @@ jpeg_idct_2x2 (j_decompress_ptr cinfo, jpeg_component_info *compptr,
     if (inptr[DCTSIZE*1] == 0 && inptr[DCTSIZE*3] == 0 &&
         inptr[DCTSIZE*5] == 0 && inptr[DCTSIZE*7] == 0) {
       /* AC terms all zero; we need not examine terms 2,4,6 for 2x2 output */
-      int dcval = LEFT_SHIFT(DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]),
-                             PASS1_BITS);
+      int dcval = (int)LEFT_SHIFT(DEQUANTIZE(inptr[DCTSIZE*0],
+                                  quantptr[DCTSIZE*0]), PASS1_BITS);
 
       wsptr[DCTSIZE*0] = dcval;
       wsptr[DCTSIZE*1] = dcval;

--- a/mozjpeg.podspec
+++ b/mozjpeg.podspec
@@ -1,0 +1,158 @@
+Pod::Spec.new do |spec|
+  spec.name = "mozjpeg"
+  spec.version = "3.3.1"
+  spec.license = { :type => "BSD" }
+  spec.homepage = "https://github.com/mozilla/mozjpeg"
+  spec.summary = "Improved JPEG encoder."
+  spec.authors = "Mozilla"
+  spec.source = { :git => "https://github.com/mozilla/mozjpeg.git", :tag => "v#{spec.version}" }
+  spec.module_name = "mozjpeg"
+  spec.header_dir = "mozjpeg"
+  spec.platforms = { :ios => "8.0" }
+  spec.prepare_command = <<-CMD
+    cat << EOF > jconfig.h
+    #define JPEG_LIB_VERSION  80	/* Version 6b */
+    #define LIBJPEG_TURBO_VERSION 3.1.m
+    #define LIBJPEG_TURBO_VERSION_NUMBER 1
+    #define C_ARITH_CODING_SUPPORTED 1
+    #define D_ARITH_CODING_SUPPORTED 1
+    #define BITS_IN_JSAMPLE  8
+    #define HAVE_LOCALE_H 1
+    #define HAVE_STDDEF_H 1
+    #define HAVE_STDLIB_H 1
+    #define HAVE_UNSIGNED_CHAR 1
+    #define HAVE_UNSIGNED_SHORT 1
+    #define NEED_SYS_TYPES_H 1
+    #define WITH_SIMD 0
+    EOF
+
+
+    cat << EOF > jconfigint.h
+    #define BUILD "20180328"
+    #define INLINE __attribute__((always_inline))
+    #define PACKAGE_NAME "mozjpeg"
+    #define VERSION "#{spec.version}"
+    #ifdef __SIZEOF_SIZE_T__
+      #define SIZEOF_SIZE_T __SIZEOF_SIZE_T__
+    #else
+      #error Cannot determine the size of size_t
+    #endif
+    EOF
+  CMD
+
+  spec.private_header_files = "bmp.h",
+                              "cderror.h",
+                              "cdjpeg.h",
+                              "jchuff.h",
+                              "jcmaster.h",
+                              "jconfigint.h",
+                              "jdcoefct.h",
+                              "jdct.h",
+                              "jdhuff.h",
+                              "jdmainct.h",
+                              "jdmaster.h",
+                              "jdsample.h",
+                              "jmemsys.h",
+                              "jpeg_nbits_table.h",
+                              "jpegcomp.h",
+                              "jsimd.h",
+                              "jsimddct.h",
+                              "jversion.h",
+                              "wrppm.h"
+
+  spec.public_header_files = "jerror.h",
+                             "jinclude.h",
+                             "jconfig.h",
+                             "jmorecfg.h",
+                             "jpeglib.h",
+                             "jpegint.h",
+                             "transupp.h"
+
+  spec.source_files = "jcapimin.c",
+                      "jcapistd.c",
+                      "jccoefct.c",
+                      "jccolor.c",
+                      "jcdctmgr.c",
+                      "jcext.c",
+                      "jchuff.c",
+                      "jcinit.c",
+                      "jcmainct.c",
+                      "jcmarker.c",
+                      "jcmaster.c",
+                      "jcomapi.c",
+                      "jcparam.c",
+                      "jcphuff.c",
+                      "jcprepct.c",
+                      "jcsample.c",
+                      "jctrans.c",
+                      "jdapimin.c",
+                      "jdapistd.c",
+                      "jdatadst.c",
+                      "jdatasrc.c",
+                      "jdcoefct.c",
+                      "jdcolor.c",
+                      "jddctmgr.c",
+                      "jdhuff.c",
+                      "jdinput.c",
+                      "jdmainct.c",
+                      "jdmarker.c",
+                      "jdmaster.c",
+                      "jdmerge.c",
+                      "jdphuff.c",
+                      "jdpostct.c",
+                      "jdsample.c",
+                      "jdtrans.c",
+                      "jerror.c",
+                      "jfdctflt.c",
+                      "jfdctfst.c",
+                      "jfdctint.c",
+                      "jidctflt.c",
+                      "jidctfst.c",
+                      "jidctint.c",
+                      "jidctred.c",
+                      "jquant1.c",
+                      "jquant2.c",
+                      "jutils.c",
+                      "jmemmgr.c",
+                      "jaricom.c",
+                      "jcarith.c",
+                      "jdarith.c",
+                      "transupp.c",
+                      "jmemnobs.c",
+                      "jsimd_none.c",
+                      "jerror.h",
+                      "jinclude.h",
+                      "jconfig.h",
+                      "jmorecfg.h",
+                      "jpeglib.h",
+                      "jpegint.h",
+                      "transupp.h",
+                      "bmp.h",
+                      "cderror.h",
+                      "cdjpeg.h",
+                      "jchuff.h",
+                      "jcmaster.h",
+                      "jconfigint.h",
+                      "jdcoefct.h",
+                      "jdct.h",
+                      "jdhuff.h",
+                      "jdmainct.h",
+                      "jdmaster.h",
+                      "jdsample.h",
+                      "jmemsys.h",
+                      "jpeg_nbits_table.h",
+                      "jpegcomp.h",
+                      "jsimd.h",
+                      "jsimddct.h",
+                      "jversion.h",
+                      "wrppm.h"
+
+  # Despite their extensions, these are header files that shouldn't be compiled
+  # on their own but should still be present for other files to include.
+  spec.preserve_path = "jdcolext.c",
+                       "jstdhuff.c",
+                       "jdcol565.c",
+                       "jdmrgext.c",
+                       "jdmrg565.c",
+                       "jccolext.c"
+end


### PR DESCRIPTION
Following on #310, adding CocoaPods support.

This PR also fixes two types of warnings being emitted by clang when running `pod lib lint`.

**Before**

```
cuva@cuva-mac ~/Developer/mozjpeg
master* $ pod spec lint
 -> mozjpeg (3.3.1)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file. (in target 'App')
    - WARN  | [iOS] xcodebuild:  mozjpeg/jidctred.c:149:19: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | [iOS] xcodebuild:  mozjpeg/jidctred.c:301:19: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | [iOS] xcodebuild:  mozjpeg/jidctint.c:211:19: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  mozjpeg/jdcol565.c:79:40: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  mozjpeg/jdcol565.c:164:40: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  mozjpeg/jdcol565.c:224:40: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  mozjpeg/jdcol565.c:283:40: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  mozjpeg/jdcol565.c:325:40: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  mozjpeg/jdcol565.c:374:40: warning: implicit conversion loses integer precision: 'JLONG' (aka 'long') to 'int' [-Wshorten-64-to-32]
    - WARN  | xcodebuild:  mozjpeg/jdcoefct.c:608:21: warning: possible misuse of comma operator here [-Wcomma]
    - NOTE  | xcodebuild:  mozjpeg/jdcoefct.c:608:9: note: cast expression to void to silence warning
    - WARN  | xcodebuild:  mozjpeg/jdcoefct.c:608:39: warning: possible misuse of comma operator here [-Wcomma]
    - NOTE  | xcodebuild:  mozjpeg/jdcoefct.c:608:23: note: cast expression to void to silence warning

Analyzed 1 podspec.

[!] The spec did not pass validation, due to 11 warnings (but you can use `--allow-warnings` to ignore them).
```

**After**
```
cuva@cuva-mac ~/Developer/mozjpeg
master* $ pod lib lint 
 -> mozjpeg (3.3.1)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file. (in target 'App')

mozjpeg passed validation.
```

Considering the current podspec is pinned to `v3.3.1` we'll need to use `--allow-warnings` when releasing 3.3.1's specs - but this shouldn't be needed for subsequent releases.

**Questions**

- I've set the license to `BSD` in the podspec - but considering the state of the license file it might be a better idea to set it as `CUSTOM`?