### PR TITLE
Add continuous integration on Windows with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Mozilla JPEG Encoder Project
+Mozilla JPEG Encoder Project [![Build Status](https://ci.appveyor.com/api/projects/status/github/mozilla/mozjpeg?branch=master&svg=true)](https://ci.appveyor.com/project/mozilla/mozjpeg)
 ============================
 
 MozJPEG reduces file sizes of JPEG images while retaining quality and compatibility with the vast majority of the world's deployed decoders.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,10 @@ configuration: Release
 
 before_build:
   ## Download nasm
-  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - cd %APPVEYOR_BUILD_FOLDER%
   - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
   - 7z e -y nasm.zip
   ## Prepare cmake
-  - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
   - cd cmake_build
   - cmake --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,4 +17,4 @@ before_build:
 build_script: cmake c:\projects\mozjpeg
 
 artifacts:
- - path: cmake_build\Release\**\*.*
+ - path: cmake_build\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,4 +20,4 @@ before_build:
 build_script: msbuild "C:\projects\mozjpeg\cmake_build\mozjpeg.sln"
 
 artifacts:
- - path: cmake_build\Release\mozjpeg*.exe
+ - path: cmake_build\**\Release\**\mozjpeg*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 configuration: Release
 
-before_build:
+install:
   ## Download nasm
   - mkdir nasm
   - cd nasm
@@ -14,7 +14,10 @@ before_build:
   - cd cmake_build
   - cmake --version
 
-build_script: cmake c:\projects\mozjpeg
+before_build:
+  - cmake c:\projects\mozjpeg
+
+build_script: msbuild "C:\projects\mozjpeg\cmake_build\mozjpeg.sln"
 
 artifacts:
- - path: cmake_build\**\*.*
+ - path: cmake_build\Release\mozjpeg*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,11 @@ configuration: Release
 
 before_build:
 - cmd: |-
+    ## Download nasm
+    appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+    appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
+    7z e -y nasm.zip
+    ## Prepare cmake
     cd %APPVEYOR_BUILD_FOLDER%
     mkdir cmake_build
     cd cmake_build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,3 +21,4 @@ build_script: msbuild "C:\projects\mozjpeg\cmake_build\mozjpeg.sln"
 
 artifacts:
  - path: cmake_build\**\Release\**\mozjpeg*.exe
+ - path: cmake_build\**\Release\**\mozjpeg*.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,5 +20,5 @@ before_build:
 build_script: msbuild "C:\projects\mozjpeg\cmake_build\mozjpeg.sln"
 
 artifacts:
- - path: cmake_build\**\Release\**\mozjpeg*.exe
- - path: cmake_build\**\Release\**\mozjpeg*.lib
+ - path: cmake_build\**\Release\**\*.exe
+ - path: cmake_build\**\Release\**\*.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,16 +2,15 @@ image: Visual Studio 2017
 configuration: Release
 
 before_build:
-- cmd: |-
-    ## Download nasm
-    appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-    appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
-    7z e -y nasm.zip
-    ## Prepare cmake
-    cd %APPVEYOR_BUILD_FOLDER%
-    mkdir cmake_build
-    cd cmake_build
-    cmake --version
+  ## Download nasm
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
+  - 7z e -y nasm.zip
+  ## Prepare cmake
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - mkdir cmake_build
+  - cd cmake_build
+  - cmake --version
 
 build_script: cmake c:\projects\mozjpeg
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,13 @@ configuration: Release
 
 before_build:
   ## Download nasm
-  - cd %APPVEYOR_BUILD_FOLDER%
+  - mkdir nasm
+  - cd nasm
   - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
   - 7z e -y nasm.zip
+  - set PATH=%PATH%;%CD%
   ## Prepare cmake
+  - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
   - cd cmake_build
   - cmake --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+image: Visual Studio 2017
+configuration: Release
+
+before_build:
+- cmd: |-
+    cd %APPVEYOR_BUILD_FOLDER%
+    mkdir cmake_build
+    cd cmake_build
+    cmake --version
+
+build_script: cmake c:\projects\mozjpeg
+
+artifacts:
+ - path: cmake_build\Release\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,9 @@ install:
   ## Prepare cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
-  - cd cmake_build
-  - cmake --version
 
 before_build:
+  - cmake --version
   - cmake
 
 build_script: cmake_build\mozjpeg.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,9 @@ install:
   - cmake --version
 
 before_build:
-  - cmake c:\projects\mozjpeg
+  - cmake
 
-build_script: msbuild "C:\projects\mozjpeg\cmake_build\mozjpeg.sln"
+build_script: cmake_build\mozjpeg.sln
 
 artifacts:
  - path: cmake_build\**\Release\**\*.exe


### PR DESCRIPTION
This patch adds continuous integration on Windows with AppVeyor. The default settings in the [CMakeLists](https://github.com/mozilla/mozjpeg/blob/master/CMakeLists.txt) are used, if any other configurations are desired let me know. AppVeyor runs from EwoutH/mozjpeg can be found [here](https://ci.appveyor.com/project/EwoutH/mozjpeg).

To integrate with GitHub AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.