### PR TITLE
Fixed broken PNG_SUPPORTED flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,8 +646,8 @@ else()
   set(DJPEG_BMP_SOURCES wrbmp.c wrtarga.c)
 
   if(PNG_SUPPORTED)
-    set(COMPILE_FLAGS ${COMPILE_FLAGS} -DPNG_SUPPORTED)
-    set(CJPEG_BMP_SOURCES ${CJPG_BMP_SOURCES} rdpng.c)
+    set(COMPILE_FLAGS "${COMPILE_FLAGS} -DPNG_SUPPORTED")
+    set(CJPEG_BMP_SOURCES ${CJPEG_BMP_SOURCES} rdpng.c)
   endif()
 endif()
 


### PR DESCRIPTION
This PR fixes the `PNG_SUPPORTED` flagging.

The two mistakes are quite trivial, but due to the typo on line 650 I honestly don't think this has ever worked, ever since it was added.