### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -94,7 +94,6 @@ Build Requirements
 
   * If using JDK 11 or later, CMake 3.10.x or later must also be used.
 
-
 - Vcpkg
   
   You can download and install mozjpeg using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -95,6 +95,19 @@ Build Requirements
   * If using JDK 11 or later, CMake 3.10.x or later must also be used.
 
 
+- Vcpkg
+  
+  You can download and install mozjpeg using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh
+  ./vcpkg integrate install
+  vcpkg install mozjpeg
+  
+  The mozjpeg port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 Out-of-Tree Builds
 ------------------
 


### PR DESCRIPTION
`Mozjpeg `is available as a port in [vcpkg](url), a C++ library manager that simplifies installation for `mozjpeg `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `mozjpeg`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/mozjpeg/portfile.cmake). We try to keep the library maintained as close as possible to the original library.