### PR TITLE
Automate Windows build and deploy (with PNG support)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,10 @@ install:
   - mkdir cmake_build
 
 before_build:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %platform%
   - cmake --version
   - cd cmake_build
-  - cmake .. -A %platform% -DWITH_CRT_DLL=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+  - cmake .. -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ install:
   - mkdir cmake_build
 
 before_build:
+  - nasm -v
   - cmake --version
   - cd cmake_build
   - cmake .. -A %PLATFORM% -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ install:
   - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
   - 7z e -y nasm.zip
   - set PATH=%PATH%;%CD%
+  - cd C:\Tools\vcpkg
+  - vcpkg install libpng
   ## Prepare cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
@@ -15,7 +17,7 @@ install:
 before_build:
   - cmake --version
   - cd cmake_build
-  - cmake .. -G "Visual Studio 15 2017" -DPNG_SUPPORTED=NO
+  - cmake .. -G "Visual Studio 15 2017" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
 before_build:
   - cmake --version
   - cd cmake_build
-  - cmake .. -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+  - cmake .. -A %platform% -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -28,9 +28,3 @@ build_script:
 artifacts:
  - path: cmake_build\**\Release\**\*.exe
  - path: cmake_build\**\Release\**\*.lib
-
-cache:
-  - C:\ProgramData\chocolatey\bin
-  - C:\ProgramData\chocolatey\lib
-  - C:\Program Files\NASM
-  - c:\tools\vcpkg\installed\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,17 @@
 image: Visual Studio 2017
 configuration: Release
+platform:
+  - x86
+  - x64
 
 install:
-  ## Download nasm
-  - mkdir nasm
-  - cd nasm
-  - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
-  - 7z e -y nasm.zip
-  - set PATH=%PATH%;%CD%
+  ## Set up nasm
+  - choco install nasm
+  - set PATH=%PATH%;"C:\Program Files\NASM"
+  ## Set up libpng
   - cd C:\Tools\vcpkg
-  - vcpkg install libpng
+  - vcpkg install libpng:x86-windows
+  - vcpkg install libpng:x64-windows
   ## Prepare cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
@@ -17,7 +19,7 @@ install:
 before_build:
   - cmake --version
   - cd cmake_build
-  - cmake .. -G "Visual Studio 15 2017" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+  - cmake .. -DWITH_CRT_DLL=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -26,3 +28,8 @@ build_script:
 artifacts:
  - path: cmake_build\**\Release\**\*.exe
  - path: cmake_build\**\Release\**\*.lib
+
+cache:
+  - C:\ProgramData\chocolatey\bin
+  - C:\ProgramData\chocolatey\lib
+  - C:\Program Files\NASM

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 configuration: Release
 platform:
-  - x86
+  - Win32
   - x64
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,23 +14,35 @@ install:
   - cd C:\Tools\vcpkg
   - vcpkg install libpng:%ARCH%-windows
   - vcpkg install libpng:%ARCH%-windows-static
-  ## Prepare cmake
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - mkdir cmake_build
 
 before_build:
   - nasm -v
   - cmake --version
-  - cd cmake_build
-  - cmake .. -A %PLATFORM% -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - cmake --build cmake_build --config Release
 
+  ## Build shared
+  - cmake -B shared -A %PLATFORM%
+          -DENABLE_SHARED=1 -DENABLE_STATIC=0
+          -DREQUIRE_SIMD=1
+          -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+  - cmake --build shared --config Release
+
+  ## Build static
+  - cmake -B static -A %PLATFORM%
+          -DENABLE_SHARED=0 -DENABLE_STATIC=1
+          -DREQUIRE_SIMD=1
+          -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -DVCPKG_TARGET_TRIPLET=x86-windows-static
+
+  - cmake --build static --config Release
+
+after_build:
+  - 7z a mozjpeg-build.zip shared static
 artifacts:
- - path: cmake_build\**\Release\**\*.exe
- - path: cmake_build\**\Release\**\*.lib
+  - path: *.zip
 
 cache:
   - C:\ProgramData\chocolatey\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ install:
   - mkdir cmake_build
 
 before_build:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
   - cmake --version
   - cd cmake_build
   - cmake .. -A %PLATFORM% -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
@@ -31,3 +30,9 @@ build_script:
 artifacts:
  - path: cmake_build\**\Release\**\*.exe
  - path: cmake_build\**\Release\**\*.lib
+
+cache:
+  - C:\ProgramData\chocolatey\bin
+  - C:\ProgramData\chocolatey\lib
+  - C:\Program Files\NASM
+  - c:\tools\vcpkg\installed\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,10 +42,10 @@ build_script:
 after_build:
   - 7z a mozjpeg-build.zip shared static
 artifacts:
-  - path: *.zip
+  - path: '*.zip'
 
 cache:
   - C:\ProgramData\chocolatey\bin
   - C:\ProgramData\chocolatey\lib
   - C:\Program Files\NASM
-  - c:\tools\vcpkg\installed\
+  - C:\tools\vcpkg\installed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,12 +35,12 @@ build_script:
           -DENABLE_SHARED=0 -DENABLE_STATIC=1
           -DREQUIRE_SIMD=1
           -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
-          -DVCPKG_TARGET_TRIPLET=x86-windows-static
+          -DVCPKG_TARGET_TRIPLET=%ARCH%-windows-static
 
   - cmake --build static --config Release
 
 after_build:
-  - 7z a mozjpeg-build.zip shared static
+  - 7z a mozjpeg-win-%ARCH%.zip shared/Release static/Release
 artifacts:
   - path: '*.zip'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ platform:
   - x64
 
 install:
-  - if %PLATFORM% == Win32 (set ARCH x86)
-  - if %PLATFORM% == x64 (set ARCH x64)
+  - if %PLATFORM% == Win32 (set ARCH=x86)
+  - if %PLATFORM% == x64 (set ARCH=x64)
   ## Set up nasm
   - choco install nasm
   - set PATH=%PATH%;"C:\Program Files\NASM"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ install:
 before_build:
   - nasm -v
   - cmake --version
+  - git describe --always --tags --dirty
+  - FOR /F %a in ('git describe --always --tags --dirty') do set GIT_VERSION=%a
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -40,7 +42,8 @@ build_script:
   - cmake --build static --config Release
 
 after_build:
-  - 7z a mozjpeg-win-%ARCH%.zip shared/Release static/Release
+  - 7z a mozjpeg-%GIT_VERSION%-win-%ARCH%.zip shared/Release static/Release
+
 artifacts:
   - path: '*.zip'
 
@@ -49,3 +52,12 @@ cache:
   - C:\ProgramData\chocolatey\lib
   - C:\Program Files\NASM
   - C:\tools\vcpkg\installed
+
+deploy:
+  description: 'Automated build using Appveyor'
+  provider: GitHub
+  auth_token:
+    secure: UyY8O91YcxiumO2NkBUGNKDzKDSW0chVj134u+7+haPlc4Naagggt4a//7hRowjL
+  artifact: /.*\.zip/
+  on:
+    APPVEYOR_REPO_TAG: true        # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,14 +16,13 @@ install:
   - vcpkg install libpng:%ARCH%-windows-static
 
 before_build:
+  - cd %APPVEYOR_BUILD_FOLDER%
   - nasm -v
   - cmake --version
   - git describe --always --tags --dirty
-  - FOR /F %a in ('git describe --always --tags --dirty') do set GIT_VERSION=%a
+  - FOR /F %%a in ('git describe --always --tags --dirty') do set GIT_VERSION=%%a
 
 build_script:
-  - cd %APPVEYOR_BUILD_FOLDER%
-
   ## Build shared
   - cmake -B shared -A %PLATFORM%
           -DENABLE_SHARED=1 -DENABLE_STATIC=0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - mkdir cmake_build
 
 before_build:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %platform%
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %platform%
   - cmake --version
   - cd cmake_build
   - cmake .. -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - if %PLATFORM% == x64 (set ARCH=x64)
   ## Set up nasm
   - choco install nasm
-  - set PATH=%PATH%;"C:\Program Files\NASM"
+  - set PATH=%PATH%;C:\Program Files\NASM
   ## Set up libpng
   - cd C:\Tools\vcpkg
   - vcpkg install libpng:%ARCH%-windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 configuration: Release
 platform:
-  - x86
+  - Win32
   - x64
 
 install:
@@ -10,13 +10,13 @@ install:
   - set PATH=%PATH%;"C:\Program Files\NASM"
   ## Set up libpng
   - cd C:\Tools\vcpkg
-  - vcpkg install libpng:%platform%-windows
+  - vcpkg install libpng:x86-windows
+  - vcpkg install libpng:x64-windows
   ## Prepare cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
 
 before_build:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %platform%
   - cmake --version
   - cd cmake_build
   - cmake .. -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
@@ -33,3 +33,4 @@ cache:
   - C:\ProgramData\chocolatey\bin
   - C:\ProgramData\chocolatey\lib
   - C:\Program Files\NASM
+  - c:\tools\vcpkg\installed\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,25 +5,28 @@ platform:
   - x64
 
 install:
+  - if %PLATFORM% == Win32 (set ARCH x86)
+  - if %PLATFORM% == x64 (set ARCH x64)
   ## Set up nasm
   - choco install nasm
   - set PATH=%PATH%;"C:\Program Files\NASM"
   ## Set up libpng
   - cd C:\Tools\vcpkg
-  - vcpkg install libpng:x86-windows
-  - vcpkg install libpng:x64-windows
+  - vcpkg install libpng:%ARCH%-windows
+  - vcpkg install libpng:%ARCH%-windows-static
   ## Prepare cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
 
 before_build:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
   - cmake --version
   - cd cmake_build
-  - cmake .. -A %platform% -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+  - cmake .. -A %PLATFORM% -DWITH_CRT_DLL=1 -DREQUIRE_SIMD=1 -DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - msbuild cmake_build\mozjpeg.sln
+  - cmake --build cmake_build --config Release
 
 artifacts:
  - path: cmake_build\**\Release\**\*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 configuration: Release
 platform:
-  - Win32
+  - x86
   - x64
 
 install:
@@ -10,8 +10,7 @@ install:
   - set PATH=%PATH%;"C:\Program Files\NASM"
   ## Set up libpng
   - cd C:\Tools\vcpkg
-  - vcpkg install libpng:x86-windows
-  - vcpkg install libpng:x64-windows
+  - vcpkg install libpng:%platform%-windows
   ## Prepare cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build
@@ -19,7 +18,7 @@ install:
 before_build:
   - cmake --version
   - cd cmake_build
-  - cmake .. -DWITH_CRT_DLL=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+  - cmake .. -A %platform% -DWITH_CRT_DLL=ON -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%


### PR DESCRIPTION
This is a PR to automate build and deploy for Windows platform (with PNG support.)

Related issues: #91, #337, #358

CI will automatically add Windows binary to Github release page on git tagging.

Build and release example is here:
https://github.com/dofuuz/mozjpeg/releases/tag/v4.0.1-buildtest
https://ci.appveyor.com/project/dofuuz/mozjpeg/builds/35456155

Changes:
- Add libpng to CI
- Build Win32/x64 variants
- Auto deploy on tag

Two things should be done to deploy Windows binary to Github release page.
- Replace github auth_token (See https://www.appveyor.com/docs/deployment/github/ )
- Add new release tag.
