### PR TITLE
CMake: fix installation of executables if iOS/tvOS/watchOS or msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1438,7 +1438,7 @@ if(WITH_TURBOJPEG)
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(TARGETS tjbench
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+      DESTINATION ${CMAKE_INSTALL_BINDIR})
     if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
       CMAKE_C_LINKER_SUPPORTS_PDB)
       install(FILES "$<TARGET_PDB_FILE:turbojpeg>"
@@ -1455,7 +1455,7 @@ if(WITH_TURBOJPEG)
       else()
         set(DIR ${CMAKE_CURRENT_BINARY_DIR})
       endif()
-      install(PROGRAMS ${DIR}/tjbench-static${EXE}
+      install(PROGRAMS $<TARGET_FILE:tjbench-static>
         DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
     endif()
   endif()
@@ -1473,16 +1473,16 @@ if(ENABLE_STATIC)
     else()
       set(DIR ${CMAKE_CURRENT_BINARY_DIR})
     endif()
-    install(PROGRAMS ${DIR}/cjpeg-static${EXE}
+    install(PROGRAMS $<TARGET_FILE:cjpeg-static>
       DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME cjpeg${EXE})
-    install(PROGRAMS ${DIR}/djpeg-static${EXE}
+    install(PROGRAMS $<TARGET_FILE:djpeg-static>
       DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME djpeg${EXE})
-    install(PROGRAMS ${DIR}/jpegtran-static${EXE}
+    install(PROGRAMS $<TARGET_FILE:jpegtran-static>
       DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jpegtran${EXE})
   endif()
 endif()
 
-install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS rdjpgcom wrjpgcom DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
   ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.txt


### PR DESCRIPTION
- For iOS/tvOS/watchOS: see https://cmake.org/cmake/help/latest/policy/CMP0006.html, RUNTIME DESTINATION only is not sufficient, BUNDLE is also required, so DESTINATION alone sets destination for all types.
- `install(PROGRAMS ${DIR}/cjpeg-static${EXE}` stuff is too fragile, and breaks with some generators, `$<TARGET_FILE:cjpeg-static>` is more robust.