### PR TITLE
Stop using register storage specifier

### DIFF
--- a/cdjpeg.c
+++ b/cdjpeg.c
@@ -96,8 +96,8 @@ end_progress_monitor(j_common_ptr cinfo)
 GLOBAL(boolean)
 keymatch(char *arg, const char *keyword, int minchars)
 {
-  register int ca, ck;
-  register int nmatched = 0;
+  int ca, ck;
+  int nmatched = 0;
 
   while ((ca = *arg++) != '\0') {
     if ((ck = *keyword++) == '\0')

--- a/jcarith.c
+++ b/jcarith.c
@@ -228,10 +228,10 @@ finish_pass(j_compress_ptr cinfo)
 LOCAL(void)
 arith_encode(j_compress_ptr cinfo, unsigned char *st, int val)
 {
-  register arith_entropy_ptr e = (arith_entropy_ptr)cinfo->entropy;
-  register unsigned char nl, nm;
-  register JLONG qe, temp;
-  register int sv;
+  arith_entropy_ptr e = (arith_entropy_ptr)cinfo->entropy;
+  unsigned char nl, nm;
+  JLONG qe, temp;
+  int sv;
 
   /* Fetch values from our compact representation of Table D.2:
    * Qe values and probability estimation state machine

--- a/jccolext.c
+++ b/jccolext.c
@@ -34,11 +34,11 @@ rgb_ycc_convert_internal(j_compress_ptr cinfo, JSAMPARRAY input_buf,
                          int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int r, g, b;
-  register JLONG *ctab = cconvert->rgb_ycc_tab;
-  register JSAMPROW inptr;
-  register JSAMPROW outptr0, outptr1, outptr2;
-  register JDIMENSION col;
+  int r, g, b;
+  JLONG *ctab = cconvert->rgb_ycc_tab;
+  JSAMPROW inptr;
+  JSAMPROW outptr0, outptr1, outptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
 
   while (--num_rows >= 0) {
@@ -88,11 +88,11 @@ rgb_gray_convert_internal(j_compress_ptr cinfo, JSAMPARRAY input_buf,
                           int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int r, g, b;
-  register JLONG *ctab = cconvert->rgb_ycc_tab;
-  register JSAMPROW inptr;
-  register JSAMPROW outptr;
-  register JDIMENSION col;
+  int r, g, b;
+  JLONG *ctab = cconvert->rgb_ycc_tab;
+  JSAMPROW inptr;
+  JSAMPROW outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
 
   while (--num_rows >= 0) {
@@ -123,9 +123,9 @@ rgb_rgb_convert_internal(j_compress_ptr cinfo, JSAMPARRAY input_buf,
                          JSAMPIMAGE output_buf, JDIMENSION output_row,
                          int num_rows)
 {
-  register JSAMPROW inptr;
-  register JSAMPROW outptr0, outptr1, outptr2;
-  register JDIMENSION col;
+  JSAMPROW inptr;
+  JSAMPROW outptr0, outptr1, outptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
 
   while (--num_rows >= 0) {

--- a/jccolor.c
+++ b/jccolor.c
@@ -377,11 +377,11 @@ cmyk_ycck_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
                   JSAMPIMAGE output_buf, JDIMENSION output_row, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int r, g, b;
-  register JLONG *ctab = cconvert->rgb_ycc_tab;
-  register JSAMPROW inptr;
-  register JSAMPROW outptr0, outptr1, outptr2, outptr3;
-  register JDIMENSION col;
+  int r, g, b;
+  JLONG *ctab = cconvert->rgb_ycc_tab;
+  JSAMPROW inptr;
+  JSAMPROW outptr0, outptr1, outptr2, outptr3;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
 
   while (--num_rows >= 0) {
@@ -427,9 +427,9 @@ METHODDEF(void)
 grayscale_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
                   JSAMPIMAGE output_buf, JDIMENSION output_row, int num_rows)
 {
-  register JSAMPROW inptr;
-  register JSAMPROW outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr;
+  JSAMPROW outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
   int instride = cinfo->input_components;
 
@@ -455,10 +455,10 @@ METHODDEF(void)
 null_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
              JDIMENSION output_row, int num_rows)
 {
-  register JSAMPROW inptr;
-  register JSAMPROW outptr, outptr0, outptr1, outptr2, outptr3;
-  register JDIMENSION col;
-  register int ci;
+  JSAMPROW inptr;
+  JSAMPROW outptr, outptr0, outptr1, outptr2, outptr3;
+  JDIMENSION col;
+  int ci;
   int nc = cinfo->num_components;
   JDIMENSION num_cols = cinfo->image_width;
 

--- a/jcdctmgr.c
+++ b/jcdctmgr.c
@@ -565,9 +565,9 @@ float_preprocess_deringing(FAST_FLOAT *data, const JQUANT_TBL *quantization_tabl
 METHODDEF(void)
 convsamp (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace)
 {
-  register DCTELEM *workspaceptr;
-  register JSAMPROW elemptr;
-  register int elemr;
+  DCTELEM *workspaceptr;
+  JSAMPROW elemptr;
+  int elemr;
 
   workspaceptr = workspace;
   for (elemr = 0; elemr < DCTSIZE; elemr++) {
@@ -584,7 +584,7 @@ convsamp (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace)
     *workspaceptr++ = (*elemptr++) - CENTERJSAMPLE;
 #else
     {
-      register int elemc;
+      int elemc;
       for (elemc = DCTSIZE; elemc > 0; elemc--)
         *workspaceptr++ = (*elemptr++) - CENTERJSAMPLE;
     }
@@ -632,7 +632,7 @@ quantize (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace)
 
 #else
 
-  register DCTELEM qval;
+  DCTELEM qval;
 
   for (i = 0; i < DCTSIZE2; i++) {
     qval = divisors[i];
@@ -766,9 +766,9 @@ METHODDEF(void)
 convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
                FAST_FLOAT *workspace)
 {
-  register FAST_FLOAT *workspaceptr;
-  register JSAMPROW elemptr;
-  register int elemr;
+  FAST_FLOAT *workspaceptr;
+  JSAMPROW elemptr;
+  int elemr;
 
   workspaceptr = workspace;
   for (elemr = 0; elemr < DCTSIZE; elemr++) {
@@ -784,7 +784,7 @@ convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
     *workspaceptr++ = (FAST_FLOAT)((*elemptr++) - CENTERJSAMPLE);
 #else
     {
-      register int elemc;
+      int elemc;
       for (elemc = DCTSIZE; elemc > 0; elemc--)
         *workspaceptr++ = (FAST_FLOAT)((*elemptr++) - CENTERJSAMPLE);
     }
@@ -797,9 +797,9 @@ METHODDEF(void)
 quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
                FAST_FLOAT *workspace)
 {
-  register FAST_FLOAT temp;
-  register int i;
-  register JCOEFPTR output_ptr = coef_block;
+  FAST_FLOAT temp;
+  int i;
+  JCOEFPTR output_ptr = coef_block;
 
   for (i = 0; i < DCTSIZE2; i++) {
     /* Apply the quantization and scaling factor */

--- a/jchuff.c
+++ b/jchuff.c
@@ -797,9 +797,9 @@ LOCAL(void)
 htest_one_block(j_compress_ptr cinfo, JCOEFPTR block, int last_dc_val,
                 long dc_counts[], long ac_counts[])
 {
-  register int temp;
-  register int nbits;
-  register int k, r;
+  int temp;
+  int nbits;
+  int k, r;
 
   /* Encode the DC coefficient difference per section F.1.2.1 */
 

--- a/jcphuff.c
+++ b/jcphuff.c
@@ -345,8 +345,8 @@ emit_bits (phuff_entropy_ptr entropy, unsigned int code, int size)
 /* Emit some bits, unless we are in gather mode */
 {
   /* This routine is heavily used, so it's worth coding tightly. */
-  register size_t put_buffer = (size_t) code;
-  register int put_bits = entropy->put_bits;
+  size_t put_buffer = (size_t) code;
+  int put_bits = entropy->put_bits;
 
   /* if size is 0, caller used an invalid Huffman table entry */
   if (size == 0)
@@ -430,7 +430,7 @@ emit_buffered_bits (phuff_entropy_ptr entropy, char *bufstart,
 LOCAL(void)
 emit_eobrun (phuff_entropy_ptr entropy)
 {
-  register int temp, nbits;
+  int temp, nbits;
 
   if (entropy->EOBRUN > 0) {    /* if there is any pending EOBRUN */
     temp = entropy->EOBRUN;
@@ -490,8 +490,8 @@ METHODDEF(boolean)
 encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp, temp2, temp3;
-  register int nbits;
+  int temp, temp2, temp3;
+  int nbits;
   int blkn, ci;
   int Al = cinfo->Al;
   JBLOCKROW block;
@@ -602,7 +602,7 @@ encode_mcu_AC_first_prepare(const JCOEF *block,
                             const int *jpeg_natural_order_start, int Sl,
                             int Al, JCOEF *values, size_t *bits)
 {
-  register int k, temp, temp2;
+  int k, temp, temp2;
   size_t zerobits = 0U;
   int Sl0 = Sl;
 
@@ -669,8 +669,8 @@ METHODDEF(boolean)
 encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp, temp2;
-  register int nbits, r;
+  int temp, temp2;
+  int nbits, r;
   int Sl = cinfo->Se - cinfo->Ss + 1;
   int Al = cinfo->Al;
   JCOEF values_unaligned[2 * DCTSIZE2 + 15];
@@ -761,7 +761,7 @@ METHODDEF(boolean)
 encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp;
+  int temp;
   int blkn;
   int Al = cinfo->Al;
   JBLOCKROW block;
@@ -833,7 +833,7 @@ encode_mcu_AC_refine_prepare(const JCOEF *block,
                              const int *jpeg_natural_order_start, int Sl,
                              int Al, JCOEF *absvalues, size_t *bits)
 {
-  register int k, temp, temp2;
+  int k, temp, temp2;
   int EOB = 0;
   size_t zerobits = 0U, signbits = 0U;
   int Sl0 = Sl;
@@ -933,7 +933,7 @@ METHODDEF(boolean)
 encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp, r, idx;
+  int temp, r, idx;
   char *BR_buffer;
   unsigned int BR;
   int Sl = cinfo->Se - cinfo->Ss + 1;

--- a/jcprepct.c
+++ b/jcprepct.c
@@ -109,7 +109,7 @@ LOCAL(void)
 expand_bottom_edge(JSAMPARRAY image_data, JDIMENSION num_cols, int input_rows,
                    int output_rows)
 {
-  register int row;
+  int row;
 
   for (row = input_rows; row < output_rows; row++) {
     jcopy_sample_rows(image_data, input_rows - 1, image_data, row, 1,

--- a/jcsample.c
+++ b/jcsample.c
@@ -94,9 +94,9 @@ LOCAL(void)
 expand_right_edge(JSAMPARRAY image_data, int num_rows, JDIMENSION input_cols,
                   JDIMENSION output_cols)
 {
-  register JSAMPROW ptr;
-  register JSAMPLE pixval;
-  register int count;
+  JSAMPROW ptr;
+  JSAMPLE pixval;
+  int count;
   int row;
   int numcols = (int)(output_cols - input_cols);
 
@@ -222,8 +222,8 @@ h2v1_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
   int outrow;
   JDIMENSION outcol;
   JDIMENSION output_cols = compptr->width_in_blocks * DCTSIZE;
-  register JSAMPROW inptr, outptr;
-  register int bias;
+  JSAMPROW inptr, outptr;
+  int bias;
 
   /* Expand input data enough to let all the output samples be generated
    * by the standard loop.  Special-casing padded output would be more
@@ -258,8 +258,8 @@ h2v2_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
   int inrow, outrow;
   JDIMENSION outcol;
   JDIMENSION output_cols = compptr->width_in_blocks * DCTSIZE;
-  register JSAMPROW inptr0, inptr1, outptr;
-  register int bias;
+  JSAMPROW inptr0, inptr1, outptr;
+  int bias;
 
   /* Expand input data enough to let all the output samples be generated
    * by the standard loop.  Special-casing padded output would be more
@@ -300,7 +300,7 @@ h2v2_smooth_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
   int inrow, outrow;
   JDIMENSION colctr;
   JDIMENSION output_cols = compptr->width_in_blocks * DCTSIZE;
-  register JSAMPROW inptr0, inptr1, above_ptr, below_ptr, outptr;
+  JSAMPROW inptr0, inptr1, above_ptr, below_ptr, outptr;
   JLONG membersum, neighsum, memberscale, neighscale;
 
   /* Expand input data enough to let all the output samples be generated
@@ -388,7 +388,7 @@ fullsize_smooth_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
   int outrow;
   JDIMENSION colctr;
   JDIMENSION output_cols = compptr->width_in_blocks * DCTSIZE;
-  register JSAMPROW inptr, above_ptr, below_ptr, outptr;
+  JSAMPROW inptr, above_ptr, below_ptr, outptr;
   JLONG membersum, neighsum, memberscale, neighscale;
   int colsum, lastcolsum, nextcolsum;
 

--- a/jdarith.c
+++ b/jdarith.c
@@ -114,10 +114,10 @@ get_byte(j_decompress_ptr cinfo)
 LOCAL(int)
 arith_decode(j_decompress_ptr cinfo, unsigned char *st)
 {
-  register arith_entropy_ptr e = (arith_entropy_ptr)cinfo->entropy;
-  register unsigned char nl, nm;
-  register JLONG qe, temp;
-  register int sv, data;
+  arith_entropy_ptr e = (arith_entropy_ptr)cinfo->entropy;
+  unsigned char nl, nm;
+  JLONG qe, temp;
+  int sv, data;
 
   /* Renormalization & data input per section D.2.6 */
   while (e->a < 0x8000L) {

--- a/jdcol565.c
+++ b/jdcol565.c
@@ -22,17 +22,17 @@ ycc_rgb565_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                             int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int y, cb, cr;
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JDIMENSION col;
+  int y, cb, cr;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
-  register int *Crrtab = cconvert->Cr_r_tab;
-  register int *Cbbtab = cconvert->Cb_b_tab;
-  register JLONG *Crgtab = cconvert->Cr_g_tab;
-  register JLONG *Cbgtab = cconvert->Cb_g_tab;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
+  int *Crrtab = cconvert->Cr_r_tab;
+  int *Cbbtab = cconvert->Cb_b_tab;
+  JLONG *Crgtab = cconvert->Cr_g_tab;
+  JLONG *Cbgtab = cconvert->Cb_g_tab;
   SHIFT_TEMPS
 
   while (--num_rows >= 0) {
@@ -101,17 +101,17 @@ ycc_rgb565D_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                              int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int y, cb, cr;
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JDIMENSION col;
+  int y, cb, cr;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
-  register int *Crrtab = cconvert->Cr_r_tab;
-  register int *Cbbtab = cconvert->Cb_b_tab;
-  register JLONG *Crgtab = cconvert->Cr_g_tab;
-  register JLONG *Cbgtab = cconvert->Cb_g_tab;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
+  int *Crrtab = cconvert->Cr_r_tab;
+  int *Cbbtab = cconvert->Cb_b_tab;
+  JLONG *Crgtab = cconvert->Cr_g_tab;
+  JLONG *Cbgtab = cconvert->Cb_g_tab;
   JLONG d0 = dither_matrix[cinfo->output_scanline & DITHER_MASK];
   SHIFT_TEMPS
 
@@ -186,9 +186,9 @@ rgb_rgb565_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                             JDIMENSION input_row, JSAMPARRAY output_buf,
                             int num_rows)
 {
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JDIMENSION col;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
   SHIFT_TEMPS
 
@@ -241,10 +241,10 @@ rgb_rgb565D_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                              JDIMENSION input_row, JSAMPARRAY output_buf,
                              int num_rows)
 {
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JDIMENSION col;
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JDIMENSION col;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   JDIMENSION num_cols = cinfo->output_width;
   JLONG d0 = dither_matrix[cinfo->output_scanline & DITHER_MASK];
   SHIFT_TEMPS
@@ -300,8 +300,8 @@ gray_rgb565_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                              JDIMENSION input_row, JSAMPARRAY output_buf,
                              int num_rows)
 {
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
 
   while (--num_rows >= 0) {
@@ -340,9 +340,9 @@ gray_rgb565D_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                               JDIMENSION input_row, JSAMPARRAY output_buf,
                               int num_rows)
 {
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   JDIMENSION num_cols = cinfo->output_width;
   JLONG d0 = dither_matrix[cinfo->output_scanline & DITHER_MASK];
 

--- a/jdcolext.c
+++ b/jdcolext.c
@@ -33,17 +33,17 @@ ycc_rgb_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                          int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int y, cb, cr;
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JDIMENSION col;
+  int y, cb, cr;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
-  register int *Crrtab = cconvert->Cr_r_tab;
-  register int *Cbbtab = cconvert->Cb_b_tab;
-  register JLONG *Crgtab = cconvert->Cr_g_tab;
-  register JLONG *Cbgtab = cconvert->Cb_g_tab;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
+  int *Crrtab = cconvert->Cr_r_tab;
+  int *Cbbtab = cconvert->Cb_b_tab;
+  JLONG *Crgtab = cconvert->Cr_g_tab;
+  JLONG *Cbgtab = cconvert->Cb_g_tab;
   SHIFT_TEMPS
 
   while (--num_rows >= 0) {
@@ -85,8 +85,8 @@ gray_rgb_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                           JDIMENSION input_row, JSAMPARRAY output_buf,
                           int num_rows)
 {
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
 
   while (--num_rows >= 0) {
@@ -115,9 +115,9 @@ rgb_rgb_convert_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                          JDIMENSION input_row, JSAMPARRAY output_buf,
                          int num_rows)
 {
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JSAMPROW outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JSAMPROW outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
 
   while (--num_rows >= 0) {

--- a/jdcolor.c
+++ b/jdcolor.c
@@ -327,11 +327,11 @@ rgb_gray_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                  JDIMENSION input_row, JSAMPARRAY output_buf, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int r, g, b;
-  register JLONG *ctab = cconvert->rgb_y_tab;
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JDIMENSION col;
+  int r, g, b;
+  JLONG *ctab = cconvert->rgb_y_tab;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
 
   while (--num_rows >= 0) {
@@ -361,9 +361,9 @@ METHODDEF(void)
 null_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
              JDIMENSION input_row, JSAMPARRAY output_buf, int num_rows)
 {
-  register JSAMPROW inptr, inptr0, inptr1, inptr2, inptr3, outptr;
-  register JDIMENSION col;
-  register int num_components = cinfo->num_components;
+  JSAMPROW inptr, inptr0, inptr1, inptr2, inptr3, outptr;
+  JDIMENSION col;
+  int num_components = cinfo->num_components;
   JDIMENSION num_cols = cinfo->output_width;
   int ci;
 
@@ -529,17 +529,17 @@ ycck_cmyk_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                   JDIMENSION input_row, JSAMPARRAY output_buf, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr)cinfo->cconvert;
-  register int y, cb, cr;
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2, inptr3;
-  register JDIMENSION col;
+  int y, cb, cr;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2, inptr3;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
-  register int *Crrtab = cconvert->Cr_r_tab;
-  register int *Cbbtab = cconvert->Cb_b_tab;
-  register JLONG *Crgtab = cconvert->Cr_g_tab;
-  register JLONG *Cbgtab = cconvert->Cb_g_tab;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
+  int *Crrtab = cconvert->Cr_r_tab;
+  int *Cbbtab = cconvert->Cb_b_tab;
+  JLONG *Crgtab = cconvert->Cr_g_tab;
+  JLONG *Cbgtab = cconvert->Cb_g_tab;
   SHIFT_TEMPS
 
   while (--num_rows >= 0) {

--- a/jdhuff.c
+++ b/jdhuff.c
@@ -283,13 +283,13 @@ jpeg_make_d_derived_tbl(j_decompress_ptr cinfo, boolean isDC, int tblno,
 
 GLOBAL(boolean)
 jpeg_fill_bit_buffer(bitread_working_state *state,
-                     register bit_buf_type get_buffer, register int bits_left,
+                     bit_buf_type get_buffer, int bits_left,
                      int nbits)
 /* Load up the bit buffer to a depth of at least nbits */
 {
   /* Copy heavily used state fields into locals (hopefully registers) */
-  register const JOCTET *next_input_byte = state->next_input_byte;
-  register size_t bytes_in_buffer = state->bytes_in_buffer;
+  const JOCTET *next_input_byte = state->next_input_byte;
+  size_t bytes_in_buffer = state->bytes_in_buffer;
   j_decompress_ptr cinfo = state->cinfo;
 
   /* Attempt to load at least MIN_GET_BITS bits into get_buffer. */
@@ -298,7 +298,7 @@ jpeg_fill_bit_buffer(bitread_working_state *state,
 
   if (cinfo->unread_marker == 0) {      /* cannot advance past a marker */
     while (bits_left < MIN_GET_BITS) {
-      register int c;
+      int c;
 
       /* Attempt to read a byte */
       if (bytes_in_buffer == 0) {
@@ -387,7 +387,7 @@ no_more_bytes:
    slower routines. */
 
 #define GET_BYTE { \
-  register int c0, c1; \
+  int c0, c1; \
   c0 = *buffer++; \
   c1 = *buffer; \
   /* Pre-execute most common case */ \
@@ -432,11 +432,11 @@ no_more_bytes:
 
 GLOBAL(int)
 jpeg_huff_decode(bitread_working_state *state,
-                 register bit_buf_type get_buffer, register int bits_left,
+                 bit_buf_type get_buffer, int bits_left,
                  d_derived_tbl *htbl, int min_bits)
 {
-  register int l = min_bits;
-  register JLONG code;
+  int l = min_bits;
+  JLONG code;
 
   /* HUFF_DECODE has determined that the code is at least min_bits */
   /* bits long, so fetch that many bits in one swoop. */
@@ -563,7 +563,7 @@ decode_mcu_slow(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
     JBLOCKROW block = MCU_data ? MCU_data[blkn] : NULL;
     d_derived_tbl *dctbl = entropy->dc_cur_tbls[blkn];
     d_derived_tbl *actbl = entropy->ac_cur_tbls[blkn];
-    register int s, k, r;
+    int s, k, r;
 
     /* Decode a single block's worth of coefficients */
 
@@ -670,7 +670,7 @@ decode_mcu_fast(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
     JBLOCKROW block = MCU_data ? MCU_data[blkn] : NULL;
     d_derived_tbl *dctbl = entropy->dc_cur_tbls[blkn];
     d_derived_tbl *actbl = entropy->ac_cur_tbls[blkn];
-    register int s, k, r, l;
+    int s, k, r, l;
 
     HUFF_DECODE_FAST(s, l, dctbl);
     if (s) {

--- a/jdhuff.h
+++ b/jdhuff.h
@@ -119,8 +119,8 @@ typedef struct {                /* Bitreading working state within an MCU */
 
 /* Macros to declare and load/save bitread local variables. */
 #define BITREAD_STATE_VARS \
-  register bit_buf_type get_buffer; \
-  register int bits_left; \
+  bit_buf_type get_buffer; \
+  int bits_left; \
   bitread_working_state br_state
 
 #define BITREAD_LOAD_STATE(cinfop, permstate) \
@@ -173,8 +173,8 @@ typedef struct {                /* Bitreading working state within an MCU */
 
 /* Load up the bit buffer to a depth of at least nbits */
 EXTERN(boolean) jpeg_fill_bit_buffer(bitread_working_state *state,
-                                     register bit_buf_type get_buffer,
-                                     register int bits_left, int nbits);
+                                     bit_buf_type get_buffer,
+                                     int bits_left, int nbits);
 
 
 /*
@@ -195,7 +195,7 @@ EXTERN(boolean) jpeg_fill_bit_buffer(bitread_working_state *state,
  */
 
 #define HUFF_DECODE(result, state, htbl, failaction, slowlabel) { \
-  register int nb, look; \
+  int nb, look; \
   if (bits_left < HUFF_LOOKAHEAD) { \
     if (!jpeg_fill_bit_buffer(&state, get_buffer, bits_left, 0)) \
       { failaction; } \
@@ -242,6 +242,6 @@ slowlabel: \
 
 /* Out-of-line case for Huffman code fetching */
 EXTERN(int) jpeg_huff_decode(bitread_working_state *state,
-                             register bit_buf_type get_buffer,
-                             register int bits_left, d_derived_tbl *htbl,
+                             bit_buf_type get_buffer,
+                             int bits_left, d_derived_tbl *htbl,
                              int min_bits);

--- a/jdmrg565.c
+++ b/jdmrg565.c
@@ -20,13 +20,13 @@ h2v1_merged_upsample_565_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                                   JSAMPARRAY output_buf)
 {
   my_merged_upsample_ptr upsample = (my_merged_upsample_ptr)cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr;
+  JSAMPROW outptr;
   JSAMPROW inptr0, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   int *Crrtab = upsample->Cr_r_tab;
   int *Cbbtab = upsample->Cb_b_tab;
   JLONG *Crgtab = upsample->Cr_g_tab;
@@ -91,13 +91,13 @@ h2v1_merged_upsample_565D_internal(j_decompress_ptr cinfo,
                                    JSAMPARRAY output_buf)
 {
   my_merged_upsample_ptr upsample = (my_merged_upsample_ptr)cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr;
+  JSAMPROW outptr;
   JSAMPROW inptr0, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   int *Crrtab = upsample->Cr_r_tab;
   int *Cbbtab = upsample->Cb_b_tab;
   JLONG *Crgtab = upsample->Cr_g_tab;
@@ -164,13 +164,13 @@ h2v2_merged_upsample_565_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                                   JSAMPARRAY output_buf)
 {
   my_merged_upsample_ptr upsample = (my_merged_upsample_ptr)cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr0, outptr1;
+  JSAMPROW outptr0, outptr1;
   JSAMPROW inptr00, inptr01, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   int *Crrtab = upsample->Cr_r_tab;
   int *Cbbtab = upsample->Cb_b_tab;
   JLONG *Crgtab = upsample->Cr_g_tab;
@@ -260,13 +260,13 @@ h2v2_merged_upsample_565D_internal(j_decompress_ptr cinfo,
                                    JSAMPARRAY output_buf)
 {
   my_merged_upsample_ptr upsample = (my_merged_upsample_ptr)cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr0, outptr1;
+  JSAMPROW outptr0, outptr1;
   JSAMPROW inptr00, inptr01, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   int *Crrtab = upsample->Cr_r_tab;
   int *Cbbtab = upsample->Cb_b_tab;
   JLONG *Crgtab = upsample->Cr_g_tab;

--- a/jdmrgext.c
+++ b/jdmrgext.c
@@ -26,13 +26,13 @@ h2v1_merged_upsample_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                               JSAMPARRAY output_buf)
 {
   my_merged_upsample_ptr upsample = (my_merged_upsample_ptr)cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr;
+  JSAMPROW outptr;
   JSAMPROW inptr0, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   int *Crrtab = upsample->Cr_r_tab;
   int *Cbbtab = upsample->Cb_b_tab;
   JLONG *Crgtab = upsample->Cr_g_tab;
@@ -98,13 +98,13 @@ h2v2_merged_upsample_internal(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
                               JSAMPARRAY output_buf)
 {
   my_merged_upsample_ptr upsample = (my_merged_upsample_ptr)cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr0, outptr1;
+  JSAMPROW outptr0, outptr1;
   JSAMPROW inptr00, inptr01, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE *range_limit = cinfo->sample_range_limit;
+  JSAMPLE *range_limit = cinfo->sample_range_limit;
   int *Crrtab = upsample->Cr_r_tab;
   int *Cbbtab = upsample->Cb_b_tab;
   JLONG *Crgtab = upsample->Cr_g_tab;

--- a/jdphuff.c
+++ b/jdphuff.c
@@ -289,7 +289,7 @@ decode_mcu_DC_first(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr)cinfo->entropy;
   int Al = cinfo->Al;
-  register int s, r;
+  int s, r;
   int blkn, ci;
   JBLOCKROW block;
   BITREAD_STATE_VARS;
@@ -366,7 +366,7 @@ decode_mcu_AC_first(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
   phuff_entropy_ptr entropy = (phuff_entropy_ptr)cinfo->entropy;
   int Se = cinfo->Se;
   int Al = cinfo->Al;
-  register int s, k, r;
+  int s, k, r;
   unsigned int EOBRUN;
   JBLOCKROW block;
   BITREAD_STATE_VARS;
@@ -503,7 +503,7 @@ decode_mcu_AC_refine(j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
   int Se = cinfo->Se;
   int p1 = 1 << cinfo->Al;        /* 1 in the bit position being coded */
   int m1 = (NEG_1) << cinfo->Al;  /* -1 in the bit position being coded */
-  register int s, k, r;
+  int s, k, r;
   unsigned int EOBRUN;
   JBLOCKROW block;
   JCOEFPTR thiscoef;

--- a/jdsample.c
+++ b/jdsample.c
@@ -160,9 +160,9 @@ int_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
 {
   my_upsample_ptr upsample = (my_upsample_ptr)cinfo->upsample;
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr, outptr;
-  register JSAMPLE invalue;
-  register int h;
+  JSAMPROW inptr, outptr;
+  JSAMPLE invalue;
+  int h;
   JSAMPROW outend;
   int h_expand, v_expand;
   int inrow, outrow;
@@ -203,8 +203,8 @@ h2v1_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
               JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
 {
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr, outptr;
-  register JSAMPLE invalue;
+  JSAMPROW inptr, outptr;
+  JSAMPLE invalue;
   JSAMPROW outend;
   int inrow;
 
@@ -231,8 +231,8 @@ h2v2_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
               JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
 {
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr, outptr;
-  register JSAMPLE invalue;
+  JSAMPROW inptr, outptr;
+  JSAMPLE invalue;
   JSAMPROW outend;
   int inrow, outrow;
 
@@ -274,9 +274,9 @@ h2v1_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
                     JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
 {
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr, outptr;
-  register int invalue;
-  register JDIMENSION colctr;
+  JSAMPROW inptr, outptr;
+  int invalue;
+  JDIMENSION colctr;
   int inrow;
 
   for (inrow = 0; inrow < cinfo->max_v_samp_factor; inrow++) {
@@ -360,13 +360,13 @@ h2v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
                     JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
 {
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr0, inptr1, outptr;
+  JSAMPROW inptr0, inptr1, outptr;
 #if BITS_IN_JSAMPLE == 8
-  register int thiscolsum, lastcolsum, nextcolsum;
+  int thiscolsum, lastcolsum, nextcolsum;
 #else
-  register JLONG thiscolsum, lastcolsum, nextcolsum;
+  JLONG thiscolsum, lastcolsum, nextcolsum;
 #endif
-  register JDIMENSION colctr;
+  JDIMENSION colctr;
   int inrow, outrow, v;
 
   inrow = outrow = 0;

--- a/jquant1.c
+++ b/jquant1.c
@@ -466,12 +466,12 @@ color_quantize(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
   JSAMPARRAY colorindex = cquantize->colorindex;
-  register int pixcode, ci;
-  register JSAMPROW ptrin, ptrout;
+  int pixcode, ci;
+  JSAMPROW ptrin, ptrout;
   int row;
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
-  register int nc = cinfo->out_color_components;
+  int nc = cinfo->out_color_components;
 
   for (row = 0; row < num_rows; row++) {
     ptrin = input_buf[row];
@@ -493,8 +493,8 @@ color_quantize3(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* Fast path for out_color_components==3, no dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
-  register int pixcode;
-  register JSAMPROW ptrin, ptrout;
+  int pixcode;
+  JSAMPROW ptrin, ptrout;
   JSAMPROW colorindex0 = cquantize->colorindex[0];
   JSAMPROW colorindex1 = cquantize->colorindex[1];
   JSAMPROW colorindex2 = cquantize->colorindex[2];
@@ -521,8 +521,8 @@ quantize_ord_dither(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* General case, with ordered dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
-  register JSAMPROW input_ptr;
-  register JSAMPROW output_ptr;
+  JSAMPROW input_ptr;
+  JSAMPROW output_ptr;
   JSAMPROW colorindex_ci;
   int *dither;                  /* points to active row of dither matrix */
   int row_index, col_index;     /* current indexes into dither matrix */
@@ -571,9 +571,9 @@ quantize3_ord_dither(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* Fast path for out_color_components==3, with ordered dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
-  register int pixcode;
-  register JSAMPROW input_ptr;
-  register JSAMPROW output_ptr;
+  int pixcode;
+  JSAMPROW input_ptr;
+  JSAMPROW output_ptr;
   JSAMPROW colorindex0 = cquantize->colorindex[0];
   JSAMPROW colorindex1 = cquantize->colorindex[1];
   JSAMPROW colorindex2 = cquantize->colorindex[2];
@@ -613,14 +613,14 @@ quantize_fs_dither(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* General case, with Floyd-Steinberg dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
-  register LOCFSERROR cur;      /* current error or pixel value */
+  LOCFSERROR cur;               /* current error or pixel value */
   LOCFSERROR belowerr;          /* error for pixel below cur */
   LOCFSERROR bpreverr;          /* error for below/prev col */
   LOCFSERROR bnexterr;          /* error for below/next col */
   LOCFSERROR delta;
-  register FSERRPTR errorptr;   /* => fserrors[] at column before current */
-  register JSAMPROW input_ptr;
-  register JSAMPROW output_ptr;
+  FSERRPTR errorptr;            /* => fserrors[] at column before current */
+  JSAMPROW input_ptr;
+  JSAMPROW output_ptr;
   JSAMPROW colorindex_ci;
   JSAMPROW colormap_ci;
   int pixcode;

--- a/jquant2.c
+++ b/jquant2.c
@@ -204,9 +204,9 @@ prescan_quantize(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
                  JSAMPARRAY output_buf, int num_rows)
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
-  register JSAMPROW ptr;
-  register histptr histp;
-  register hist3d histogram = cquantize->histogram;
+  JSAMPROW ptr;
+  histptr histp;
+  hist3d histogram = cquantize->histogram;
   int row;
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
@@ -253,9 +253,9 @@ find_biggest_color_pop(boxptr boxlist, int numboxes)
 /* Find the splittable box with the largest color population */
 /* Returns NULL if no splittable boxes remain */
 {
-  register boxptr boxp;
-  register int i;
-  register long maxc = 0;
+  boxptr boxp;
+  int i;
+  long maxc = 0;
   boxptr which = NULL;
 
   for (i = 0, boxp = boxlist; i < numboxes; i++, boxp++) {
@@ -273,9 +273,9 @@ find_biggest_volume(boxptr boxlist, int numboxes)
 /* Find the splittable box with the largest (scaled) volume */
 /* Returns NULL if no splittable boxes remain */
 {
-  register boxptr boxp;
-  register int i;
-  register JLONG maxv = 0;
+  boxptr boxp;
+  int i;
+  JLONG maxv = 0;
   boxptr which = NULL;
 
   for (i = 0, boxp = boxlist; i < numboxes; i++, boxp++) {
@@ -406,7 +406,7 @@ median_cut(j_decompress_ptr cinfo, boxptr boxlist, int numboxes,
 {
   int n, lb;
   int c0, c1, c2, cmax;
-  register boxptr b1, b2;
+  boxptr b1, b2;
 
   while (numboxes < desired_colors) {
     /* Select box to split.
@@ -762,12 +762,12 @@ find_best_colors(j_decompress_ptr cinfo, int minc0, int minc1, int minc2,
 {
   int ic0, ic1, ic2;
   int i, icolor;
-  register JLONG *bptr;         /* pointer into bestdist[] array */
+  JLONG *bptr;         /* pointer into bestdist[] array */
   JSAMPLE *cptr;                /* pointer into bestcolor[] array */
   JLONG dist0, dist1;           /* initial distance values */
-  register JLONG dist2;         /* current distance in inner loop */
+  JLONG dist2;         /* current distance in inner loop */
   JLONG xx0, xx1;               /* distance increments */
-  register JLONG xx2;
+  JLONG xx2;
   JLONG inc0, inc1, inc2;       /* initial values for increments */
   /* This array holds the distance to the nearest-so-far color for each cell */
   JLONG bestdist[BOX_C0_ELEMS * BOX_C1_ELEMS * BOX_C2_ELEMS];
@@ -840,8 +840,8 @@ fill_inverse_cmap(j_decompress_ptr cinfo, int c0, int c1, int c2)
   hist3d histogram = cquantize->histogram;
   int minc0, minc1, minc2;      /* lower left corner of update box */
   int ic0, ic1, ic2;
-  register JSAMPLE *cptr;       /* pointer into bestcolor[] array */
-  register histptr cachep;      /* pointer into main cache array */
+  JSAMPLE *cptr;       /* pointer into bestcolor[] array */
+  histptr cachep;      /* pointer into main cache array */
   /* This array lists the candidate colormap indexes. */
   JSAMPLE colorlist[MAXNUMCOLORS];
   int numcolors;                /* number of candidate colors */
@@ -897,9 +897,9 @@ pass2_no_dither(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
   hist3d histogram = cquantize->histogram;
-  register JSAMPROW inptr, outptr;
-  register histptr cachep;
-  register int c0, c1, c2;
+  JSAMPROW inptr, outptr;
+  histptr cachep;
+  int c0, c1, c2;
   int row;
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
@@ -931,10 +931,10 @@ pass2_fs_dither(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr)cinfo->cquantize;
   hist3d histogram = cquantize->histogram;
-  register LOCFSERROR cur0, cur1, cur2; /* current error or pixel value */
+  LOCFSERROR cur0, cur1, cur2; /* current error or pixel value */
   LOCFSERROR belowerr0, belowerr1, belowerr2; /* error for pixel below cur */
   LOCFSERROR bpreverr0, bpreverr1, bpreverr2; /* error for below/prev col */
-  register FSERRPTR errorptr;   /* => fserrors[] at column before current */
+  FSERRPTR errorptr;   /* => fserrors[] at column before current */
   JSAMPROW inptr;               /* => current input pixel */
   JSAMPROW outptr;              /* => current output pixel */
   histptr cachep;
@@ -1012,7 +1012,7 @@ pass2_fs_dither(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
                           cur2 >> C2_SHIFT);
       /* Now emit the colormap index for this cell */
       {
-        register int pixcode = *cachep - 1;
+        int pixcode = *cachep - 1;
         *outptr = (JSAMPLE)pixcode;
         /* Compute representation error for this pixel */
         cur0 -= colormap0[pixcode];
@@ -1024,7 +1024,7 @@ pass2_fs_dither(j_decompress_ptr cinfo, JSAMPARRAY input_buf,
        * next-line error sums left by 1 column.
        */
       {
-        register LOCFSERROR bnexterr;
+        LOCFSERROR bnexterr;
 
         bnexterr = cur0;        /* Process component 0 */
         errorptr[0] = (FSERROR)(bpreverr0 + cur0 * 3);

--- a/jutils.c
+++ b/jutils.c
@@ -100,9 +100,9 @@ jcopy_sample_rows(JSAMPARRAY input_array, int source_row,
  * The source and destination arrays must be at least as wide as num_cols.
  */
 {
-  register JSAMPROW inptr, outptr;
-  register size_t count = (size_t)(num_cols * sizeof(JSAMPLE));
-  register int row;
+  JSAMPROW inptr, outptr;
+  size_t count = (size_t)(num_cols * sizeof(JSAMPLE));
+  int row;
 
   input_array += source_row;
   output_array += dest_row;

--- a/md5/md5.c
+++ b/md5/md5.c
@@ -193,7 +193,7 @@ void MD5Final(unsigned char digest[16], struct MD5Context *ctx)
  */
 void MD5Transform(uint32 buf[4], uint32 in[16])
 {
-  register uint32 a, b, c, d;
+  uint32 a, b, c, d;
 
   a = buf[0];
   b = buf[1];

--- a/rdbmp.c
+++ b/rdbmp.c
@@ -81,8 +81,8 @@ LOCAL(int)
 read_byte(bmp_source_ptr sinfo)
 /* Read next byte from BMP file */
 {
-  register FILE *infile = sinfo->pub.input_file;
-  register int c;
+  FILE *infile = sinfo->pub.input_file;
+  int c;
 
   if ((c = getc(infile)) == EOF)
     ERREXIT(sinfo->cinfo, JERR_INPUT_EOF);
@@ -145,12 +145,12 @@ get_8bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading 8-bit colormap indexes */
 {
   bmp_source_ptr source = (bmp_source_ptr)sinfo;
-  register JSAMPARRAY colormap = source->colormap;
+  JSAMPARRAY colormap = source->colormap;
   int cmaplen = source->cmap_length;
   JSAMPARRAY image_ptr;
-  register int t;
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
+  int t;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
 
   if (source->use_inversion_array) {
     /* Fetch next row from virtual array */
@@ -184,11 +184,11 @@ get_8bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
       outptr += 4;
     }
   } else {
-    register int rindex = rgb_red[cinfo->in_color_space];
-    register int gindex = rgb_green[cinfo->in_color_space];
-    register int bindex = rgb_blue[cinfo->in_color_space];
-    register int aindex = alpha_index[cinfo->in_color_space];
-    register int ps = rgb_pixelsize[cinfo->in_color_space];
+    int rindex = rgb_red[cinfo->in_color_space];
+    int gindex = rgb_green[cinfo->in_color_space];
+    int bindex = rgb_blue[cinfo->in_color_space];
+    int aindex = alpha_index[cinfo->in_color_space];
+    int ps = rgb_pixelsize[cinfo->in_color_space];
 
     if (aindex >= 0) {
       for (col = cinfo->image_width; col > 0; col--) {
@@ -224,8 +224,8 @@ get_24bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   bmp_source_ptr source = (bmp_source_ptr)sinfo;
   JSAMPARRAY image_ptr;
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
 
   if (source->use_inversion_array) {
     /* Fetch next row from virtual array */
@@ -253,11 +253,11 @@ get_24bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
       outptr += 4;
     }
   } else {
-    register int rindex = rgb_red[cinfo->in_color_space];
-    register int gindex = rgb_green[cinfo->in_color_space];
-    register int bindex = rgb_blue[cinfo->in_color_space];
-    register int aindex = alpha_index[cinfo->in_color_space];
-    register int ps = rgb_pixelsize[cinfo->in_color_space];
+    int rindex = rgb_red[cinfo->in_color_space];
+    int gindex = rgb_green[cinfo->in_color_space];
+    int bindex = rgb_blue[cinfo->in_color_space];
+    int aindex = alpha_index[cinfo->in_color_space];
+    int ps = rgb_pixelsize[cinfo->in_color_space];
 
     if (aindex >= 0) {
       for (col = cinfo->image_width; col > 0; col--) {
@@ -287,8 +287,8 @@ get_32bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   bmp_source_ptr source = (bmp_source_ptr)sinfo;
   JSAMPARRAY image_ptr;
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
 
   if (source->use_inversion_array) {
     /* Fetch next row from virtual array */
@@ -318,11 +318,11 @@ get_32bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
       outptr += 4;
     }
   } else {
-    register int rindex = rgb_red[cinfo->in_color_space];
-    register int gindex = rgb_green[cinfo->in_color_space];
-    register int bindex = rgb_blue[cinfo->in_color_space];
-    register int aindex = alpha_index[cinfo->in_color_space];
-    register int ps = rgb_pixelsize[cinfo->in_color_space];
+    int rindex = rgb_red[cinfo->in_color_space];
+    int gindex = rgb_green[cinfo->in_color_space];
+    int bindex = rgb_blue[cinfo->in_color_space];
+    int aindex = alpha_index[cinfo->in_color_space];
+    int ps = rgb_pixelsize[cinfo->in_color_space];
 
     if (aindex >= 0) {
       for (col = cinfo->image_width; col > 0; col--) {
@@ -357,8 +357,8 @@ METHODDEF(JDIMENSION)
 preload_image(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   bmp_source_ptr source = (bmp_source_ptr)sinfo;
-  register FILE *infile = source->pub.input_file;
-  register JSAMPROW out_ptr;
+  FILE *infile = source->pub.input_file;
+  JSAMPROW out_ptr;
   JSAMPARRAY image_ptr;
   JDIMENSION row;
   cd_progress_ptr progress = (cd_progress_ptr)cinfo->progress;

--- a/rdcolmap.c
+++ b/rdcolmap.c
@@ -122,7 +122,7 @@ pbm_getc(FILE *infile)
 /* Read next char, skipping over any comments */
 /* A comment/newline sequence is returned as a newline */
 {
-  register int ch;
+  int ch;
 
   ch = getc(infile);
   if (ch == '#') {
@@ -141,8 +141,8 @@ read_pbm_integer(j_decompress_ptr cinfo, FILE *infile)
 /* Note that on a 16-bit-int machine, only values up to 64k can be read. */
 /* This should not be a problem in practice. */
 {
-  register int ch;
-  register unsigned int val;
+  int ch;
+  unsigned int val;
 
   /* Skip any leading whitespace */
   do {

--- a/rdgif.c
+++ b/rdgif.c
@@ -141,8 +141,8 @@ LOCAL(int)
 ReadByte(gif_source_ptr sinfo)
 /* Read next byte from GIF file */
 {
-  register FILE *infile = sinfo->pub.input_file;
-  register int c;
+  FILE *infile = sinfo->pub.input_file;
+  int c;
 
   if ((c = getc(infile)) == EOF)
     ERREXIT(sinfo->cinfo, JERR_INPUT_EOF);
@@ -214,7 +214,7 @@ GetCode(gif_source_ptr sinfo)
 /* Fetch the next code_size bits from the GIF data */
 /* We assume code_size is less than 16 */
 {
-  register int accum;
+  int accum;
   int offs, count;
 
   while (sinfo->cur_bit + sinfo->code_size > sinfo->last_bit) {
@@ -262,7 +262,7 @@ LOCAL(int)
 LZWReadByte(gif_source_ptr sinfo)
 /* Read an LZW-compressed byte */
 {
-  register int code;            /* current working code */
+  int code;            /* current working code */
   int incode;                   /* saves actual input code */
 
   /* If any codes are stacked from a previously read symbol, return them */
@@ -550,10 +550,10 @@ METHODDEF(JDIMENSION)
 get_pixel_rows(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   gif_source_ptr source = (gif_source_ptr)sinfo;
-  register int c;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
-  register JSAMPARRAY colormap = source->colormap;
+  int c;
+  JSAMPROW ptr;
+  JDIMENSION col;
+  JSAMPARRAY colormap = source->colormap;
 
   ptr = source->pub.buffer[0];
   for (col = cinfo->image_width; col > 0; col--) {
@@ -576,8 +576,8 @@ METHODDEF(JDIMENSION)
 load_interlaced_image(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   gif_source_ptr source = (gif_source_ptr)sinfo;
-  register JSAMPROW sptr;
-  register JDIMENSION col;
+  JSAMPROW sptr;
+  JDIMENSION col;
   JDIMENSION row;
   cd_progress_ptr progress = (cd_progress_ptr)cinfo->progress;
 
@@ -620,10 +620,10 @@ METHODDEF(JDIMENSION)
 get_interlaced_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   gif_source_ptr source = (gif_source_ptr)sinfo;
-  register int c;
-  register JSAMPROW sptr, ptr;
-  register JDIMENSION col;
-  register JSAMPARRAY colormap = source->colormap;
+  int c;
+  JSAMPROW sptr, ptr;
+  JDIMENSION col;
+  JSAMPARRAY colormap = source->colormap;
   JDIMENSION irow;
 
   /* Figure out which row of interlaced image is needed, and access it. */

--- a/rdjpgcom.c
+++ b/rdjpgcom.c
@@ -423,8 +423,8 @@ keymatch(char *arg, const char *keyword, int minchars)
 /* keyword is the constant keyword (must be lower case already), */
 /* minchars is length of minimum legal abbreviation. */
 {
-  register int ca, ck;
-  register int nmatched = 0;
+  int ca, ck;
+  int nmatched = 0;
 
   while ((ca = *arg++) != '\0') {
     if ((ck = *keyword++) == '\0')

--- a/rdppm.c
+++ b/rdppm.c
@@ -76,7 +76,7 @@ pbm_getc(FILE *infile)
 /* Read next char, skipping over any comments */
 /* A comment/newline sequence is returned as a newline */
 {
-  register int ch;
+  int ch;
 
   ch = getc(infile);
   if (ch == '#') {
@@ -95,8 +95,8 @@ read_pbm_integer(j_compress_ptr cinfo, FILE *infile, unsigned int maxval)
 /* Note that on a 16-bit-int machine, only values up to 64k can be read. */
 /* This should not be a problem in practice. */
 {
-  register int ch;
-  register unsigned int val;
+  int ch;
+  unsigned int val;
 
   /* Skip any leading whitespace */
   do {
@@ -137,8 +137,8 @@ get_text_gray_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
   FILE *infile = source->pub.input_file;
-  register JSAMPROW ptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
 
@@ -165,15 +165,15 @@ get_text_gray_rgb_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
   FILE *infile = source->pub.input_file;
-  register JSAMPROW ptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
-  register int rindex = rgb_red[cinfo->in_color_space];
-  register int gindex = rgb_green[cinfo->in_color_space];
-  register int bindex = rgb_blue[cinfo->in_color_space];
-  register int aindex = alpha_index[cinfo->in_color_space];
-  register int ps = rgb_pixelsize[cinfo->in_color_space];
+  int rindex = rgb_red[cinfo->in_color_space];
+  int gindex = rgb_green[cinfo->in_color_space];
+  int bindex = rgb_blue[cinfo->in_color_space];
+  int aindex = alpha_index[cinfo->in_color_space];
+  int ps = rgb_pixelsize[cinfo->in_color_space];
 
   ptr = source->pub.buffer[0];
   if (maxval == MAXJSAMPLE) {
@@ -200,8 +200,8 @@ get_text_gray_cmyk_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
   FILE *infile = source->pub.input_file;
-  register JSAMPROW ptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
 
@@ -239,15 +239,15 @@ get_text_rgb_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
   FILE *infile = source->pub.input_file;
-  register JSAMPROW ptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
-  register int rindex = rgb_red[cinfo->in_color_space];
-  register int gindex = rgb_green[cinfo->in_color_space];
-  register int bindex = rgb_blue[cinfo->in_color_space];
-  register int aindex = alpha_index[cinfo->in_color_space];
-  register int ps = rgb_pixelsize[cinfo->in_color_space];
+  int rindex = rgb_red[cinfo->in_color_space];
+  int gindex = rgb_green[cinfo->in_color_space];
+  int bindex = rgb_blue[cinfo->in_color_space];
+  int aindex = alpha_index[cinfo->in_color_space];
+  int ps = rgb_pixelsize[cinfo->in_color_space];
 
   ptr = source->pub.buffer[0];
   if (maxval == MAXJSAMPLE) {
@@ -274,8 +274,8 @@ get_text_rgb_cmyk_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
   FILE *infile = source->pub.input_file;
-  register JSAMPROW ptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
 
@@ -306,9 +306,9 @@ get_scaled_gray_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading raw-byte-format PGM files with any maxval */
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register U_CHAR *bufferptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  U_CHAR *bufferptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
 
   if (!ReadOK(source->pub.input_file, source->iobuffer, source->buffer_width))
@@ -328,16 +328,16 @@ get_gray_rgb_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
    and converting to extended RGB */
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register U_CHAR *bufferptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  U_CHAR *bufferptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
-  register int rindex = rgb_red[cinfo->in_color_space];
-  register int gindex = rgb_green[cinfo->in_color_space];
-  register int bindex = rgb_blue[cinfo->in_color_space];
-  register int aindex = alpha_index[cinfo->in_color_space];
-  register int ps = rgb_pixelsize[cinfo->in_color_space];
+  int rindex = rgb_red[cinfo->in_color_space];
+  int gindex = rgb_green[cinfo->in_color_space];
+  int bindex = rgb_blue[cinfo->in_color_space];
+  int aindex = alpha_index[cinfo->in_color_space];
+  int ps = rgb_pixelsize[cinfo->in_color_space];
 
   if (!ReadOK(source->pub.input_file, source->iobuffer, source->buffer_width))
     ERREXIT(cinfo, JERR_INPUT_EOF);
@@ -364,9 +364,9 @@ get_gray_cmyk_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
    and converting to CMYK */
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register U_CHAR *bufferptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  U_CHAR *bufferptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
 
@@ -396,16 +396,16 @@ get_rgb_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading raw-byte-format PPM files with any maxval */
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register U_CHAR *bufferptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  U_CHAR *bufferptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
-  register int rindex = rgb_red[cinfo->in_color_space];
-  register int gindex = rgb_green[cinfo->in_color_space];
-  register int bindex = rgb_blue[cinfo->in_color_space];
-  register int aindex = alpha_index[cinfo->in_color_space];
-  register int ps = rgb_pixelsize[cinfo->in_color_space];
+  int rindex = rgb_red[cinfo->in_color_space];
+  int gindex = rgb_green[cinfo->in_color_space];
+  int bindex = rgb_blue[cinfo->in_color_space];
+  int aindex = alpha_index[cinfo->in_color_space];
+  int ps = rgb_pixelsize[cinfo->in_color_space];
 
   if (!ReadOK(source->pub.input_file, source->iobuffer, source->buffer_width))
     ERREXIT(cinfo, JERR_INPUT_EOF);
@@ -432,9 +432,9 @@ get_rgb_cmyk_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
    converting to CMYK */
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register U_CHAR *bufferptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  U_CHAR *bufferptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
 
@@ -483,9 +483,9 @@ get_word_gray_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading raw-word-format PGM files with any maxval */
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register U_CHAR *bufferptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  U_CHAR *bufferptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
 
@@ -494,7 +494,7 @@ get_word_gray_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
   ptr = source->pub.buffer[0];
   bufferptr = source->iobuffer;
   for (col = cinfo->image_width; col > 0; col--) {
-    register unsigned int temp;
+    unsigned int temp;
     temp  = UCH(*bufferptr++) << 8;
     temp |= UCH(*bufferptr++);
     if (temp > maxval)
@@ -510,23 +510,23 @@ get_word_rgb_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading raw-word-format PPM files with any maxval */
 {
   ppm_source_ptr source = (ppm_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register U_CHAR *bufferptr;
-  register JSAMPLE *rescale = source->rescale;
+  JSAMPROW ptr;
+  U_CHAR *bufferptr;
+  JSAMPLE *rescale = source->rescale;
   JDIMENSION col;
   unsigned int maxval = source->maxval;
-  register int rindex = rgb_red[cinfo->in_color_space];
-  register int gindex = rgb_green[cinfo->in_color_space];
-  register int bindex = rgb_blue[cinfo->in_color_space];
-  register int aindex = alpha_index[cinfo->in_color_space];
-  register int ps = rgb_pixelsize[cinfo->in_color_space];
+  int rindex = rgb_red[cinfo->in_color_space];
+  int gindex = rgb_green[cinfo->in_color_space];
+  int bindex = rgb_blue[cinfo->in_color_space];
+  int aindex = alpha_index[cinfo->in_color_space];
+  int ps = rgb_pixelsize[cinfo->in_color_space];
 
   if (!ReadOK(source->pub.input_file, source->iobuffer, source->buffer_width))
     ERREXIT(cinfo, JERR_INPUT_EOF);
   ptr = source->pub.buffer[0];
   bufferptr = source->iobuffer;
   for (col = cinfo->image_width; col > 0; col--) {
-    register unsigned int temp;
+    unsigned int temp;
     temp  = UCH(*bufferptr++) << 8;
     temp |= UCH(*bufferptr++);
     if (temp > maxval)

--- a/rdswitch.c
+++ b/rdswitch.c
@@ -26,7 +26,7 @@ text_getc (FILE *file)
 /* Read next char, skipping over any comments (# to end of line) */
 /* A comment/newline sequence is returned as a newline */
 {
-  register int ch;
+  int ch;
 
   ch = getc(file);
   if (ch == '#') {
@@ -43,8 +43,8 @@ read_text_integer (FILE *file, long *result, int *termchar)
 /* Read an unsigned decimal integer from a file, store it in result */
 /* Reads one trailing character after the integer; returns it in termchar */
 {
-  register int ch;
-  register long val;
+  int ch;
+  long val;
 
   /* Skip any leading whitespace, detect EOF */
   do {
@@ -144,7 +144,7 @@ read_scan_integer (FILE *file, long *result, int *termchar)
  * this simplifies parsing of punctuation in scan scripts.
  */
 {
-  register int ch;
+  int ch;
 
   if (! read_text_integer(file, result, termchar))
     return FALSE;

--- a/rdtarga.c
+++ b/rdtarga.c
@@ -83,8 +83,8 @@ LOCAL(int)
 read_byte(tga_source_ptr sinfo)
 /* Read next byte from Targa file */
 {
-  register FILE *infile = sinfo->pub.input_file;
-  register int c;
+  FILE *infile = sinfo->pub.input_file;
+  int c;
 
   if ((c = getc(infile)) == EOF)
     ERREXIT(sinfo->cinfo, JERR_INPUT_EOF);
@@ -118,7 +118,7 @@ METHODDEF(void)
 read_non_rle_pixel(tga_source_ptr sinfo)
 /* Read one Targa pixel from the input file; no RLE expansion */
 {
-  register int i;
+  int i;
 
   for (i = 0; i < sinfo->pixel_size; i++) {
     sinfo->tga_pixel[i] = (U_CHAR)read_byte(sinfo);
@@ -130,7 +130,7 @@ METHODDEF(void)
 read_rle_pixel(tga_source_ptr sinfo)
 /* Read one Targa pixel from the input file, expanding RLE data as needed */
 {
-  register int i;
+  int i;
 
   /* Duplicate previously read pixel? */
   if (sinfo->dup_pixel_count > 0) {
@@ -168,8 +168,8 @@ get_8bit_gray_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading 8-bit grayscale pixels */
 {
   tga_source_ptr source = (tga_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
+  JSAMPROW ptr;
+  JDIMENSION col;
 
   ptr = source->pub.buffer[0];
   for (col = cinfo->image_width; col > 0; col--) {
@@ -184,10 +184,10 @@ get_8bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading 8-bit colormap indexes */
 {
   tga_source_ptr source = (tga_source_ptr)sinfo;
-  register int t;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
-  register JSAMPARRAY colormap = source->colormap;
+  int t;
+  JSAMPROW ptr;
+  JDIMENSION col;
+  JSAMPARRAY colormap = source->colormap;
   int cmaplen = source->cmap_length;
 
   ptr = source->pub.buffer[0];
@@ -208,9 +208,9 @@ get_16bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading 16-bit pixels */
 {
   tga_source_ptr source = (tga_source_ptr)sinfo;
-  register int t;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
+  int t;
+  JSAMPROW ptr;
+  JDIMENSION col;
 
   ptr = source->pub.buffer[0];
   for (col = cinfo->image_width; col > 0; col--) {
@@ -236,8 +236,8 @@ get_24bit_row(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
 /* This version is for reading 24-bit pixels */
 {
   tga_source_ptr source = (tga_source_ptr)sinfo;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
+  JSAMPROW ptr;
+  JDIMENSION col;
 
   ptr = source->pub.buffer[0];
   for (col = cinfo->image_width; col > 0; col--) {

--- a/simd/mips64/jcsample.h
+++ b/simd/mips64/jcsample.h
@@ -11,9 +11,9 @@ LOCAL(void)
 expand_right_edge(JSAMPARRAY image_data, int num_rows, JDIMENSION input_cols,
                   JDIMENSION output_cols)
 {
-  register JSAMPROW ptr;
-  register JSAMPLE pixval;
-  register int count;
+  JSAMPROW ptr;
+  JSAMPLE pixval;
+  int count;
   int row;
   int numcols = (int)(output_cols - input_cols);
 

--- a/simd/powerpc/jcsample.h
+++ b/simd/powerpc/jcsample.h
@@ -11,9 +11,9 @@ LOCAL(void)
 expand_right_edge(JSAMPARRAY image_data, int num_rows, JDIMENSION input_cols,
                   JDIMENSION output_cols)
 {
-  register JSAMPROW ptr;
-  register JSAMPLE pixval;
-  register int count;
+  JSAMPROW ptr;
+  JSAMPLE pixval;
+  int count;
   int row;
   int numcols = (int)(output_cols - input_cols);
 

--- a/wrbmp.c
+++ b/wrbmp.c
@@ -100,8 +100,8 @@ put_pixel_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
 {
   bmp_dest_ptr dest = (bmp_dest_ptr)dinfo;
   JSAMPARRAY image_ptr;
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
   int pad;
 
   if (dest->use_inversion_array) {
@@ -146,10 +146,10 @@ put_pixel_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
       outptr += 3;
     }
   } else {
-    register int rindex = rgb_red[cinfo->out_color_space];
-    register int gindex = rgb_green[cinfo->out_color_space];
-    register int bindex = rgb_blue[cinfo->out_color_space];
-    register int ps = rgb_pixelsize[cinfo->out_color_space];
+    int rindex = rgb_red[cinfo->out_color_space];
+    int gindex = rgb_green[cinfo->out_color_space];
+    int bindex = rgb_blue[cinfo->out_color_space];
+    int ps = rgb_pixelsize[cinfo->out_color_space];
 
     for (col = cinfo->output_width; col > 0; col--) {
       outptr[0] = inptr[bindex];
@@ -175,7 +175,7 @@ put_gray_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
 {
   bmp_dest_ptr dest = (bmp_dest_ptr)dinfo;
   JSAMPARRAY image_ptr;
-  register JSAMPROW inptr, outptr;
+  JSAMPROW inptr, outptr;
   int pad;
 
   if (dest->use_inversion_array) {
@@ -432,9 +432,9 @@ METHODDEF(void)
 finish_output_bmp(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo)
 {
   bmp_dest_ptr dest = (bmp_dest_ptr)dinfo;
-  register FILE *outfile = dest->pub.output_file;
+  FILE *outfile = dest->pub.output_file;
   JSAMPARRAY image_ptr;
-  register JSAMPROW data_ptr;
+  JSAMPROW data_ptr;
   JDIMENSION row;
   cd_progress_ptr progress = (cd_progress_ptr)cinfo->progress;
 

--- a/wrgif.c
+++ b/wrgif.c
@@ -358,12 +358,12 @@ put_LZW_pixel_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
                    JDIMENSION rows_supplied)
 {
   gif_dest_ptr dest = (gif_dest_ptr)dinfo;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
+  JSAMPROW ptr;
+  JDIMENSION col;
   code_int c;
-  register hash_int i;
-  register hash_int disp;
-  register hash_entry probe_value;
+  hash_int i;
+  hash_int disp;
+  hash_entry probe_value;
 
   ptr = dest->pub.buffer[0];
   for (col = cinfo->output_width; col > 0; col--) {
@@ -459,8 +459,8 @@ put_raw_pixel_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
                    JDIMENSION rows_supplied)
 {
   gif_dest_ptr dest = (gif_dest_ptr)dinfo;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
+  JSAMPROW ptr;
+  JDIMENSION col;
   code_int c;
 
   ptr = dest->pub.buffer[0];

--- a/wrjpgcom.c
+++ b/wrjpgcom.c
@@ -380,8 +380,8 @@ keymatch(char *arg, const char *keyword, int minchars)
 /* keyword is the constant keyword (must be lower case already), */
 /* minchars is length of minimum legal abbreviation. */
 {
-  register int ca, ck;
-  register int nmatched = 0;
+  int ca, ck;
+  int nmatched = 0;
 
   while ((ca = *arg++) != '\0') {
     if ((ck = *keyword++) == '\0')

--- a/wrppm.c
+++ b/wrppm.c
@@ -47,7 +47,7 @@
 #else
 /* The word-per-sample format always puts the MSB first. */
 #define PUTPPMSAMPLE(ptr, v) { \
-  register int val_ = v; \
+  int val_ = v; \
   *ptr++ = (char)((val_ >> 8) & 0xFF); \
   *ptr++ = (char)(val_ & 0xFF); \
 }
@@ -106,10 +106,10 @@ copy_pixel_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
                 JDIMENSION rows_supplied)
 {
   ppm_dest_ptr dest = (ppm_dest_ptr)dinfo;
-  register char *bufferptr;
-  register JSAMPROW ptr;
+  char *bufferptr;
+  JSAMPROW ptr;
 #if BITS_IN_JSAMPLE != 8
-  register JDIMENSION col;
+  JDIMENSION col;
 #endif
 
   ptr = dest->pub.buffer[0];
@@ -133,13 +133,13 @@ METHODDEF(void)
 put_rgb(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo, JDIMENSION rows_supplied)
 {
   ppm_dest_ptr dest = (ppm_dest_ptr)dinfo;
-  register char *bufferptr;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
-  register int rindex = rgb_red[cinfo->out_color_space];
-  register int gindex = rgb_green[cinfo->out_color_space];
-  register int bindex = rgb_blue[cinfo->out_color_space];
-  register int ps = rgb_pixelsize[cinfo->out_color_space];
+  char *bufferptr;
+  JSAMPROW ptr;
+  JDIMENSION col;
+  int rindex = rgb_red[cinfo->out_color_space];
+  int gindex = rgb_green[cinfo->out_color_space];
+  int bindex = rgb_blue[cinfo->out_color_space];
+  int ps = rgb_pixelsize[cinfo->out_color_space];
 
   ptr = dest->pub.buffer[0];
   bufferptr = dest->iobuffer;
@@ -162,9 +162,9 @@ put_cmyk(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
          JDIMENSION rows_supplied)
 {
   ppm_dest_ptr dest = (ppm_dest_ptr)dinfo;
-  register char *bufferptr;
-  register JSAMPROW ptr;
-  register JDIMENSION col;
+  char *bufferptr;
+  JSAMPROW ptr;
+  JDIMENSION col;
 
   ptr = dest->pub.buffer[0];
   bufferptr = dest->iobuffer;
@@ -189,13 +189,13 @@ put_demapped_rgb(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
                  JDIMENSION rows_supplied)
 {
   ppm_dest_ptr dest = (ppm_dest_ptr)dinfo;
-  register char *bufferptr;
-  register int pixval;
-  register JSAMPROW ptr;
-  register JSAMPROW color_map0 = cinfo->colormap[0];
-  register JSAMPROW color_map1 = cinfo->colormap[1];
-  register JSAMPROW color_map2 = cinfo->colormap[2];
-  register JDIMENSION col;
+  char *bufferptr;
+  int pixval;
+  JSAMPROW ptr;
+  JSAMPROW color_map0 = cinfo->colormap[0];
+  JSAMPROW color_map1 = cinfo->colormap[1];
+  JSAMPROW color_map2 = cinfo->colormap[2];
+  JDIMENSION col;
 
   ptr = dest->pub.buffer[0];
   bufferptr = dest->iobuffer;
@@ -214,10 +214,10 @@ put_demapped_gray(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
                   JDIMENSION rows_supplied)
 {
   ppm_dest_ptr dest = (ppm_dest_ptr)dinfo;
-  register char *bufferptr;
-  register JSAMPROW ptr;
-  register JSAMPROW color_map = cinfo->colormap[0];
-  register JDIMENSION col;
+  char *bufferptr;
+  JSAMPROW ptr;
+  JSAMPROW color_map = cinfo->colormap[0];
+  JDIMENSION col;
 
   ptr = dest->pub.buffer[0];
   bufferptr = dest->iobuffer;

--- a/wrtarga.c
+++ b/wrtarga.c
@@ -95,9 +95,9 @@ put_pixel_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
 /* used for unquantized full-color output */
 {
   tga_dest_ptr dest = (tga_dest_ptr)dinfo;
-  register JSAMPROW inptr;
-  register char *outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr;
+  char *outptr;
+  JDIMENSION col;
 
   inptr = dest->pub.buffer[0];
   outptr = dest->iobuffer;
@@ -116,8 +116,8 @@ put_gray_rows(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
 /* used for grayscale OR quantized color output */
 {
   tga_dest_ptr dest = (tga_dest_ptr)dinfo;
-  register JSAMPROW inptr;
-  register char *outptr;
+  JSAMPROW inptr;
+  char *outptr;
 
   inptr = dest->pub.buffer[0];
   outptr = dest->iobuffer;
@@ -136,10 +136,10 @@ put_demapped_gray(j_decompress_ptr cinfo, djpeg_dest_ptr dinfo,
                   JDIMENSION rows_supplied)
 {
   tga_dest_ptr dest = (tga_dest_ptr)dinfo;
-  register JSAMPROW inptr;
-  register char *outptr;
-  register JSAMPROW color_map0 = cinfo->colormap[0];
-  register JDIMENSION col;
+  JSAMPROW inptr;
+  char *outptr;
+  JSAMPROW color_map0 = cinfo->colormap[0];
+  JDIMENSION col;
 
   inptr = dest->pub.buffer[0];
   outptr = dest->iobuffer;


### PR DESCRIPTION
Register was removed from C++17 and it makes clang-cl to issue a warning / fail in -Werror mode.

I suggest removing these specifiers as I believe that compiler can distribute registers in a more effective way.