### PR TITLE
Fix undefined reference to `ceilf` in build on Linux x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -868,6 +868,10 @@ if(ENABLE_STATIC)
 
   add_executable(example-static example.c)
   target_link_libraries(example-static jpeg-static)
+  if(UNIX)
+    target_link_libraries(example-static m)
+  endif()
+
 endif()
 
 add_executable(rdjpgcom rdjpgcom.c)


### PR DESCRIPTION
This PR addresses the build failure caused by an undefined reference to `ceilf` on Linux x86_64 after commit [c6d33b6](https://github.com/mozilla/mozjpeg/commit/c6d33b6d69c06bc8ac8fe7379aed18255552dd70).

Fixes #445 